### PR TITLE
react-components: Let application provide connector instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Concordium dApp Libraries
 
-A collection of libraries for making it easy for dApp developers to create robust dApps that do interesting things
+A collection of TypeScript libraries for making it easy for dApp developers to create robust dApps that do interesting things
 on the Concordium blockchain.
 
 They allow the developer to focus on their core application without having to worry about the low level details of
@@ -16,12 +16,11 @@ The project currently includes the following libraries:
 
 - [`@concordium/wallet-connectors`](./packages/wallet-connectors):
   Interfaces for interacting with wallets along with implementations for Browser Wallet and WalletConnect (v2).
-  It’s written in TypeScript and has no dependencies to any UI framework.
+  The library has no dependencies to any UI framework.
 
 - [`@concordium/react-components`](./packages/react-components):
-  React components and hooks for implementing common behaviors.
-  The component only manage React state and pass data to application components.
-  They don’t render any HTML nor do styling.
+  React components and hooks for implementing features commonly needed by dApps.
+  The components only manage React state and pass data to application components - no actual HTML is being rendered.
 
 The project also includes a sample dApp [`concordium-dapp-contractupdate`](./samples/contractupdate) as an example
 of how to integrate the libraries.

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   `WithWalletConnector`: Decouple component from concrete connector implementations by constructing instances from the application.
+    This also introduces the ability for applications to control the activation/deactivation lifecycle of the connectors.
+
 ## [0.1.0] - 2023-01-17
 
 ### Added

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -26,7 +26,6 @@
         "@tsconfig/recommended": "^1.0.1",
         "@types/node": "^18.11.17",
         "@types/react": "^18",
-        "@walletconnect/types": "^2.1.4",
         "prettier": "2.8.1",
         "typescript": "^4.9.4"
     },

--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -1,15 +1,67 @@
 import { Component } from 'react';
-import { SignClientTypes } from '@walletconnect/types';
-import {
-    BrowserWalletConnector,
-    Network,
-    WalletConnectConnector,
-    WalletConnection,
-    WalletConnectionDelegate,
-    WalletConnector,
-} from '@concordium/wallet-connectors';
+import { Network, WalletConnection, WalletConnectionDelegate, WalletConnector } from '@concordium/wallet-connectors';
 
-export type ConnectorType = 'BrowserWallet' | 'WalletConnect';
+/**
+ * Activation/deactivation controller of a given connector type.
+ */
+export interface ConnectorType {
+    /**
+     * Called when the connection type is being activated.
+     * The connector instance returned by this method becomes the new {@link State.activeConnector activeConnector}.
+     * @param component The component in which the instance is being activated.
+     *                  This object doubles as the delegate to pass to new connector instances.
+     * @param network The network to pass to new connector instances.
+     */
+    activate(component: WithWalletConnector, network: Network): Promise<WalletConnector>;
+
+    /**
+     * Called from {@link WithWalletConnector} when the connection type is being deactivated,
+     * i.e. right after {@link State.activeConnector activeConnector} has been unset from this value.
+     * @param component The component in which the instance is being deactivated.
+     * @param connector The connector to deactivate.
+     */
+    deactivate(component: WithWalletConnector, connector: WalletConnector): Promise<void>;
+}
+
+/**
+ * Produce a {@link ConnectorType} that creates a new connector instance on activation
+ * and disconnects the existing one on deactivation.
+ * This is the simplest connection type and should be used unless there's a reason not to.
+ * @param create Factory function for creating new connector instances.
+ */
+export function ephemeralConnectorType(create: (c: WithWalletConnector, n: Network) => Promise<WalletConnector>) {
+    return {
+        activate: create,
+        deactivate: (w: WithWalletConnector, c: WalletConnector) => c.disconnect(),
+    };
+}
+
+/**
+ * Produce a {@link ConnectorType} that reuse connectors between activation cycles.
+ * That is, once a connector is created, it's never automatically disconnected.
+ * Note that only the connector is permanent. Individual connections may still be disconnected by the application.
+ * @param create Factory function for creating new connector instances.
+ */
+export function persistentConnectorType(create: (c: WithWalletConnector, n: Network) => Promise<WalletConnector>) {
+    const connectorPromises = new Map<WithWalletConnector, Map<Network, Promise<WalletConnector>>>();
+    return {
+        activate: (component: WithWalletConnector, network: Network) => {
+            const delegateConnectorPromises =
+                connectorPromises.get(component) || new Map<Network, Promise<WalletConnector>>();
+            connectorPromises.set(component, delegateConnectorPromises);
+            const connectorPromise = delegateConnectorPromises.get(network) || create(component, network);
+            delegateConnectorPromises.set(network, connectorPromise);
+            connectorPromise
+                .then((connector) => connector.getConnections())
+                .then((connections) => {
+                    // If the connector already has a connection, set it as active.
+                    component.setActiveConnection(connections.length ? connections[0] : undefined);
+                });
+            return connectorPromise;
+        },
+        deactivate: async (component: WithWalletConnector) => component.setActiveConnection(undefined),
+    };
+}
 
 /**
  * The internal state of the component.
@@ -17,40 +69,28 @@ export type ConnectorType = 'BrowserWallet' | 'WalletConnect';
 interface State {
     /**
      * The active connector type. This value is updated using {@link WalletConnectionProps.setActiveConnectorType}.
-     * Changes to this value trigger new connectors to be initialized appropriately.
+     * Changes to this value trigger activation of a connector managed by the connector type.
      * This will cause {@link activeConnector} or {@link activeConnectorError} to change depending on the outcome.
-     *
-     * There currently is no way to provide an existing connector when changing the connector type
-     * as it isn't clear if this ability would be useful in practice.
      */
     activeConnectorType: ConnectorType | undefined;
 
     /**
-     * The active connector. New connectors get created automatically when {@link activeConnectorType} changes.
+     * The active connector. Connector instances get (de)activated appropriately when {@link activeConnectorType} changes.
      *
-     * Existing connectors are not disconnected automatically;
-     * this may be done using {@link WalletConnectionProps.disconnectActive}.
+     * It's up to the {@link ConnectorType} in {@link activeConnectorType} to implement any synchronization between
+     * the active connector and {@link activeConnector}:
+     * In general, it is perfectly possible for the active connection to not originate from the active connector.
      *
-     * The hook {@link useWalletConnectorSelector} adds a little more structure to the connector state
-     * and also takes care of disconnecting existing connectors as mentioned above.
-     *
-     * Note that the connector stored in this field only controls the creation of new connections.
-     * In particular, when a new connector becomes active, the current value of {@link activeConnection} is not touched.
-     * It is therefore perfectly possible for the active connection to not originate from the active connector.
-     *
-     * The reason for this behavior is it isn't obvious that one would always want this synchronization.
-     * And whenever one does, it's easy for the app to just disconnect the existing connection before changing the connector.
-     *
-     * The same is true the other way: Changes to {@link activeConnection} don't cause changes to this field as the only
-     * allowed way to change the connector is through setting the connector type.
+     * If the application disconnects the active connector manually, they must also call
+     * {@link WalletConnectionProps.setActiveConnectorType} to
      */
     activeConnector: WalletConnector | undefined;
 
     /**
      * Any of the following kinds of errors:
-     * - Error initializing a connector with a type of the current value of {@link activeConnectorType}.
+     * - Error activating a connector with {@link activeConnectorType}.
      *   In this case {@link activeConnector} is undefined.
-     * - Error disconnecting the previous connector.
+     * - Error deactivating the previous connector.
      *   In this case {@link activeConnectorType} and {@link activeConnector} are undefined.
      * - Error initiating a connection from the connector.
      *   In this case {@link activeConnector} is not undefined.
@@ -65,26 +105,40 @@ interface State {
     /**
      * The currently active connection.
      *
-     * For reasons explained in {@link activeConnector},
-     * there's no guarantee that this connection originates from the current value of {@link activeConnector}
-     * as there's no automatic synchronization between them.
+     * As explained in {@link activeConnector},
+     * this connection generally might not originate from {@link activeConnector}.
      */
     activeConnection: WalletConnection | undefined;
 
     /**
-     * The hash of the genesis block for the chain that {@link activeConnectedAccount} lives on.
+     * A map from open connections to their selected accounts.
+     * Connections without a selected account will not have an entry in this map.
+     */
+    connectedAccounts: Map<WalletConnection, string>;
+
+    /**
+     * A map from open connections to the hash of the genesis block for the chain that the selected accounts
+     * of the connections live on.
+     * Connections without a selected account (or the account's chain is unknown) will not have an entry in this map.
      *
-     * TODO The value of this field is not too reliable as it's updated only when the `onChainChanged` event fires.
+     * TODO The reported hash values are not too reliable as they're updated only when the `onChainChanged` event fires.
      *      And this doesn't happen when the connection is initiated.
      *      For WalletConnect we could do that manually as we control what chain we connect to.
      *      For BrowserWallet we don't have that option (see also https://concordium.atlassian.net/browse/CBW-633).
      */
-    activeConnectionGenesisHash: string | undefined;
+    genesisHashes: Map<WalletConnection, string>;
+}
 
-    /**
-     * The selected account of {@link activeConnection}.
-     */
-    activeConnectedAccount: string | undefined;
+function updateMapEntry<K, V>(map: Map<K, V>, key: K | undefined, value: V | undefined) {
+    const res = new Map(map);
+    if (key) {
+        if (value) {
+            res.set(key, value);
+        } else {
+            res.delete(key);
+        }
+    }
+    return res;
 }
 
 interface Props {
@@ -94,13 +148,6 @@ interface Props {
      * Changes to this value will cause all connections managed by {@link State.activeConnector} to get disconnected.
      */
     network: Network; // reacting to change in 'componentDidUpdate'
-
-    /**
-     * WalletConnect configuration.
-     * The component will use the current value of this field when initializing WalletConnect connections,
-     * but existing connections will not be affected by changes to the value.
-     */
-    walletConnectOpts: SignClientTypes.Options;
 
     /**
      * Function for generating the child component based on the props derived from the state of this component.
@@ -125,10 +172,19 @@ export interface WalletConnectionProps extends State {
     network: Network;
 
     /**
+     * The selected account of {@link activeConnection}.
+     */
+    activeConnectedAccount: string | undefined;
+
+    /**
+     * The hash of the genesis block for the chain that {@link activeConnectedAccount} lives on.
+     */
+    activeConnectionGenesisHash: string | undefined;
+
+    /**
      * Function for setting or resetting {@link State.activeConnectorType activeConnectorType}.
      *
-     * There currently is no way to provide an existing connector when changing the connector type
-     * as it isn't clear if this ability would be useful in practice.
+     * Any existing connector type value is deactivated and any new one is activated.
      *
      * @param type The new connector type or undefined to reset the value.
      */
@@ -136,7 +192,9 @@ export interface WalletConnectionProps extends State {
 
     /**
      * Function for setting or resetting {@link State.activeConnection activeConnection}.
-     * For reasons explained in the documentation of that field, this function does not touch the active connector.
+     * For reasons explained in the documentation of that field,
+     * calling this function does not cause {@link State.activeConnectorType activeConnector type}
+     * nor {@link State.activeConnector activeConnector} to change.
      * @param connection The wallet connection.
      */
     setActiveConnection: (connection: WalletConnection | undefined) => void;
@@ -148,14 +206,6 @@ export interface WalletConnectionProps extends State {
      * This does not automatically disconnect any existing connections.
      */
     connectActive: () => void;
-
-    /**
-     * Disconnect all connections owned by {@link State.activeConnector activeConnector} and reset this field,
-     * destroying its existing value.
-     *
-     * This function is called automatically when {@link network} changes.
-     */
-    disconnectActive: () => void;
 }
 
 /**
@@ -184,8 +234,8 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
             activeConnectorError: '',
             isConnecting: false,
             activeConnection: undefined,
-            activeConnectionGenesisHash: undefined,
-            activeConnectedAccount: undefined,
+            genesisHashes: new Map(),
+            connectedAccounts: new Map(),
         };
     }
 
@@ -195,35 +245,41 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
     setActiveConnectorType = (type: ConnectorType | undefined) => {
         console.debug("WithWalletConnector: calling 'setActiveConnectorType'", { type, state: this.state });
         const { network } = this.props;
-        const { activeConnectorType } = this.state;
-        if (type === activeConnectorType) {
-            return; // ensure idempotency
-        }
+        const { activeConnectorType, activeConnector } = this.state;
         this.setState({
             activeConnectorType: type,
             activeConnector: undefined,
-            activeConnection: undefined,
             activeConnectorError: '',
             isConnecting: false,
-            activeConnectionGenesisHash: undefined,
-            activeConnectedAccount: undefined,
         });
-        if (!type) {
-            return; // don't create a new connector
-        }
-        this.createConnector(type, network)
-            .then((connector: WalletConnector) => {
-                console.log('WithWalletConnector: setting active connector', { connector });
-                // Switch the connector type back in case the user changed it since initiating the connection.
-                this.setState({ activeConnectorType: type, activeConnector: connector, activeConnectorError: '' });
-            })
-            .catch((err) => {
-                if (this.state.activeConnectorType === type) {
+        if (activeConnectorType && activeConnector) {
+            activeConnectorType.deactivate(this, activeConnector).catch((err) =>
+                this.setState((state) => {
                     // Don't set error if user switched connector type since initializing this connector.
                     // It's OK to show it if the user switched away and back...
-                    this.setState({ activeConnectorError: (err as Error).message });
-                }
-            });
+                    if (state.activeConnectorType !== type) {
+                        return state;
+                    }
+                    return { ...state, activeConnectorError: (err as Error).message };
+                })
+            );
+        }
+        if (type) {
+            type.activate(this, network)
+                .then((connector: WalletConnector) => {
+                    console.log('WithWalletConnector: setting active connector', { connector });
+                    // Switch the connector (type) back in case the user changed it since initiating the connection.
+                    this.setState({ activeConnectorType: type, activeConnector: connector, activeConnectorError: '' });
+                })
+                .catch((err) =>
+                    this.setState((state) => {
+                        if (state.activeConnectorType !== type) {
+                            return state;
+                        }
+                        return { ...state, activeConnectorError: (err as Error).message };
+                    })
+                );
+        }
     };
 
     /**
@@ -231,68 +287,72 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
      */
     setActiveConnection = (connection: WalletConnection | undefined) => {
         console.debug("WithWalletConnector: calling 'setActiveConnection'", { connection, state: this.state });
-        // Not setting the active connector to that of the connection for reasons described in
-        // the docstring of `State.activeConnection`.
-        connection?.getConnectedAccount().then((connectedAccount) => {
-            console.log('WithWalletConnector: updating active connection and connected account state', {
-                connection,
-                connectedAccount,
-            });
-            this.setState({
-                activeConnection: connection,
-                activeConnectedAccount: connectedAccount,
-            });
-        });
-    };
+        // NOTE As described in the docstring of `State.activeConnection`,
+        //      setting the active connection doesn't imply that the active connector should be set as well.
+        this.setState((state) => ({
+            ...state,
+            activeConnection: connection,
+            connectedAccounts: updateMapEntry(state.connectedAccounts, state.activeConnection, undefined),
+        }));
+        if (connection) {
+            connection.getConnectedAccount().then((connectedAccount) => {
+                // This might be redundant for existing connections as the delegate already listens for account change events.
+                // But for new connections we might get the account from the connector without having received any events.
+                console.log('WithWalletConnector: updating active connection and connected account state', {
+                    connection,
+                    connectedAccount,
+                });
 
-    private createConnector = (connectorType: ConnectorType, network: Network): Promise<WalletConnector> => {
-        console.debug("WithWalletConnector: calling 'createConnector'", { connectorType, network, state: this.state });
-        const { walletConnectOpts } = this.props;
-        switch (connectorType) {
-            case 'BrowserWallet':
-                console.log('WithWalletConnector: initializing Browser Wallet connector');
-                return BrowserWalletConnector.create(this);
-            case 'WalletConnect':
-                console.log('WithWalletConnector: initializing WalletConnect connector');
-                return WalletConnectConnector.create(walletConnectOpts, network, this);
-            default:
-                throw new Error(`invalid connector type '${connectorType}'`);
+                // Don't set connected accounts if the active connection changed while loading the accounts.
+                this.setState((state) => {
+                    const { activeConnection, connectedAccounts } = state;
+                    if (activeConnection !== connection) {
+                        return state;
+                    }
+                    return {
+                        ...state,
+                        connectedAccounts: updateMapEntry(connectedAccounts, connection, connectedAccount),
+                    };
+                });
+            });
         }
     };
 
     onAccountChanged = (connection: WalletConnection, address: string | undefined) => {
         console.debug("WithWalletConnector: calling 'onAccountChanged'", { connection, address, state: this.state });
-        const { activeConnection } = this.state;
-        // Ignore event on connections other than the active one.
-        if (connection === activeConnection) {
-            console.log('WithWalletConnector: updating connected account state', { address });
-            this.setState({ activeConnectedAccount: address });
-        }
+        this.setState((state) => ({
+            ...state,
+            connectedAccounts: updateMapEntry(state.connectedAccounts, connection, address),
+        }));
     };
 
     onChainChanged = (connection: WalletConnection, genesisHash: string) => {
         console.debug("WithWalletConnector: calling 'onChainChanged'", { connection, genesisHash, state: this.state });
-        const { activeConnection } = this.state;
-        if (connection === activeConnection) {
-            this.setState({ activeConnectionGenesisHash: genesisHash });
-        }
+        this.setState((state) => ({
+            ...state,
+            genesisHashes: updateMapEntry(state.genesisHashes, connection, genesisHash),
+        }));
     };
 
     onConnected = () => undefined;
 
     onDisconnected = (connection: WalletConnection) => {
         console.debug("WithWalletConnector: calling 'onDisconnect'", { connection, state: this.state });
-        const { activeConnection } = this.state;
-        // Ignore event on connections other than the active one.
-        if (connection === activeConnection) {
-            console.log('WithWalletConnector: clearing wallet connection and connected account state');
-            this.setState({ activeConnection: undefined, activeConnectedAccount: undefined });
-        }
+        this.setState((state) => ({
+            ...state,
+            activeConnection: connection === state.activeConnection ? undefined : state.activeConnection,
+            connectedAccounts: updateMapEntry(state.connectedAccounts, connection, undefined),
+        }));
     };
 
     /**
      * @see WalletConnectionProps.connectActive
      */
+    // The method does not support creating connections with any other connector besides `activeConnector`
+    // because that could cause `activeConnectorError` to hold an error that isn't from the active connector.
+    // If the error was split into one for connector error and one for connection error, this wouldn't be a problem.
+    // As an alternative to having this method altogether, we could add an event `onConnection` to `WalletConnectionDelegate`.
+    // Then the application would just call `connect` directly on the connector and have this component pick it up automatically.
     connectActive = () => {
         console.debug("WithWalletConnector: calling 'connectActive'", { state: this.state });
         const { activeConnector } = this.state;
@@ -307,50 +367,44 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
                     }
                 })
                 .catch((err) => {
-                    if (this.state.activeConnector === activeConnector) {
-                        this.setState({ activeConnectorError: (err as Error).message });
-                    }
+                    this.setState((state) => {
+                        if (state.activeConnector !== activeConnector) {
+                            return state;
+                        }
+                        return { ...state, activeConnectorError: (err as Error).message };
+                    });
                 })
                 .finally(() => {
-                    if (this.state.activeConnector === activeConnector) {
-                        this.setState({ isConnecting: false });
-                    }
+                    this.setState((state) => {
+                        if (state.activeConnector !== activeConnector) {
+                            return state;
+                        }
+                        return { ...state, isConnecting: false };
+                    });
                 });
-        }
-    };
-
-    /**
-     * @see WalletConnectionProps.disconnectActive
-     */
-    disconnectActive = () => {
-        console.debug("WithWalletConnector: calling 'disconnectActive'", { state: this.state });
-        const { activeConnector } = this.state;
-        if (activeConnector) {
-            activeConnector.disconnect().catch((err) => {
-                if (this.state.activeConnector === activeConnector) {
-                    this.setState({ activeConnectorError: (err as Error).message });
-                }
-            });
         }
     };
 
     render() {
         const { children, network } = this.props;
+        const { connectedAccounts, genesisHashes, activeConnection } = this.state;
         return children({
             ...this.state,
             network,
+            activeConnectedAccount: activeConnection && connectedAccounts.get(activeConnection),
+            activeConnectionGenesisHash: activeConnection && genesisHashes.get(activeConnection),
             setActiveConnectorType: this.setActiveConnectorType,
             setActiveConnection: this.setActiveConnection,
             connectActive: this.connectActive,
-            disconnectActive: this.disconnectActive,
         });
     }
 
     componentDidUpdate(prevProps: Props) {
         if (prevProps.network !== this.props.network) {
-            // Disconnect everything when user changes network.
+            // Reset active connector and connection when user changes network.
             // In the future there may be a mechanism for negotiating with the wallet.
-            this.disconnectActive();
+            this.setActiveConnectorType(undefined);
+            this.setActiveConnection(undefined);
         }
     }
 

--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -131,8 +131,8 @@ interface State {
 
 function updateMapEntry<K, V>(map: Map<K, V>, key: K | undefined, value: V | undefined) {
     const res = new Map(map);
-    if (key) {
-        if (value) {
+    if (key !== undefined) {
+        if (value !== undefined) {
             res.set(key, value);
         } else {
             res.delete(key);

--- a/packages/react-components/src/useWalletConnectorSelector.ts
+++ b/packages/react-components/src/useWalletConnectorSelector.ts
@@ -30,14 +30,10 @@ export interface WalletConnectorSelector {
 }
 /**
  * React hook for managing a connector selector (usually a button in the UI).
- * To maximize flexibility, the basic {@link WithWalletConnector} tries to add as few constraints as possible
- * on how the connectors are used.
- * To implement a common case, this hook adds the additional rule that only one connector can exist at any given time.
- * Connections not belonging to this connector are automatically disconnected.
  *
  * More precisely, the hook computes the derived state {@link WalletConnectorSelector} from {@link props} as follows:
- * - The selector is {@link WalletConnectorSelector.isSelected selected} if the active connector has type {@link connectorType}.
- * - The selector is {@link WalletConnectorSelector.isConnected connected} if it is selected and has an active connection.
+ * - The selector is {@link WalletConnectorSelector.isSelected selected} if the active connector's type is {@link connectorType}.
+ * - The selector is {@link WalletConnectorSelector.isConnected connected} if it is selected and the active connection was created by the active connector.
  * - The selector is {@link WalletConnectorSelector.isDisabled disabled} if it there is another connected selector.
  *
  * It also exposes a {@link WalletConnectorSelector.select handler function} for connecting/disconnecting appropriately
@@ -51,14 +47,13 @@ export function useWalletConnectorSelector(
     connectorType: ConnectorType,
     props: WalletConnectionProps
 ): WalletConnectorSelector {
-    const { disconnectActive, activeConnectorType, activeConnector, activeConnection, setActiveConnectorType } = props;
+    const { activeConnectorType, activeConnector, activeConnection, setActiveConnectorType } = props;
     const isSelected = activeConnectorType === connectorType;
-    const select = useCallback(() => {
-        disconnectActive();
-        // TODO Use isSelected here and remove redundant values from the list of dependencies.
-        setActiveConnectorType(activeConnectorType === connectorType ? undefined : connectorType);
-    }, [connectorType, activeConnector, activeConnectorType]);
-    const isConnected = Boolean(isSelected && activeConnection); // the hook's semantics ensures that activeConnection originates from this connector
-    const isDisabled = Boolean(activeConnectorType && activeConnectorType !== connectorType && activeConnection);
+    const select = useCallback(
+        () => setActiveConnectorType(isSelected ? undefined : connectorType),
+        [isSelected, connectorType]
+    );
+    const isConnected = Boolean(isSelected && activeConnection && activeConnection.getConnector() === activeConnector);
+    const isDisabled = Boolean(!isSelected && activeConnectorType && activeConnection);
     return { isSelected, isConnected, isDisabled, select };
 }

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `WalletConnectionDelegate`: Added `onConnected` event method and renamed `onDisconnect` to `onDisconnected`
     for consistency.
+-   `WalletConnect`: Reorder constructor parameters to accommodate changes in `@concordium/react-components`.
 
 ## [0.1.0] - 2023-01-17
 

--- a/packages/wallet-connectors/README.md
+++ b/packages/wallet-connectors/README.md
@@ -83,7 +83,7 @@ In the appropriate context, set up connectors for both Browser Wallet and Wallet
 ```typescript
 const delegate = new MyDelegate();
 const browserWalletConnector = await BrowserWalletConnector.create(delegate);
-const walletConnectConnector = await WalletConnectConnector.create(walletConnectOpts, network, delegate);
+const walletConnectConnector = await WalletConnectConnector.create(walletConnectOpts, delegate, network);
 
 const browserWalletConnection = await browserWalletConnector.connect();
 const walletConnectConnection = await walletConnectConnector.connect();

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -281,10 +281,10 @@ export class WalletConnectConnector implements WalletConnector {
      * The constructor sets up event handling and appropriate forwarding to the provided delegate.
      *
      * @param client The underlying WalletConnect client.
-     * @param network The network/chain that connected accounts must live on.
      * @param delegate The object to receive events emitted by the client.
+     * @param network The network/chain that connected accounts must live on.
      */
-    constructor(client: SignClient, network: Network, delegate: WalletConnectionDelegate) {
+    constructor(client: SignClient, delegate: WalletConnectionDelegate, network: Network) {
         this.client = client;
         this.network = network;
         this.delegate = delegate;
@@ -330,16 +330,16 @@ export class WalletConnectConnector implements WalletConnector {
      * Convenience function for creating a new instance from WalletConnection configuration instead of an already initialized client.
      *
      * @param signClientInitOpts WalletConnect configuration.
-     * @param network The network/chain that connected accounts must live on.
      * @param delegate The object to receive events emitted by the client.
+     * @param network The network/chain that connected accounts must live on.
      */
     static async create(
         signClientInitOpts: SignClientTypes.Options,
-        network: Network,
-        delegate: WalletConnectionDelegate
+        delegate: WalletConnectionDelegate,
+        network: Network
     ) {
         const client = await SignClient.init(signClientInitOpts);
-        return new WalletConnectConnector(client, network, delegate);
+        return new WalletConnectConnector(client, delegate, network);
     }
 
     async connect() {

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -1,51 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Col, Container, Row } from 'react-bootstrap';
-import { Network, withJsonRpcClient } from '@concordium/react-components';
-import { SignClientTypes } from '@walletconnect/types';
+import { withJsonRpcClient } from '@concordium/react-components';
 import { WalletConnectionProps, WithWalletConnector } from '@concordium/react-components';
 import { WalletConnectionButton } from './WalletConnectionButton';
 import { WalletConnectorButton } from './WalletConnectorButton';
 import { ConnectedAccount } from './ConnectedAccount';
 import { App } from './App';
 import { NetworkSelector } from './NetworkSelector';
-
-export const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
-export const MAINNET_GENESIS_BLOCK_HASH = '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
-export const WALLET_CONNECT_PROJECT_ID = '76324905a70fe5c388bab46d3e0564dc';
-
-const testnet: Network = {
-    name: 'testnet',
-    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
-    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
-    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
-};
-const mainnet: Network = {
-    name: 'mainnet',
-    genesisHash: MAINNET_GENESIS_BLOCK_HASH,
-    jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software',
-    ccdScanBaseUrl: 'https://ccdscan.io',
-};
-const networks = [testnet, mainnet];
-
-const walletConnectOpts: SignClientTypes.Options = {
-    projectId: WALLET_CONNECT_PROJECT_ID,
-    metadata: {
-        name: 'Contract Update',
-        description: 'Example dApp for the performing an update on a contract.',
-        url: '#',
-        icons: ['https://walletconnect.com/walletconnect-logo.png'],
-    },
-};
+import { BROWSER_WALLET, MAINNET, TESTNET, WALLET_CONNECT } from './config';
 
 export default function Root() {
-    const [network, setNetwork] = useState(testnet);
+    const [network, setNetwork] = useState(TESTNET);
     return (
         <Container>
             <h1>Sample dApp</h1>
-            <NetworkSelector selected={network} options={networks} select={setNetwork} />
-            <WithWalletConnector walletConnectOpts={walletConnectOpts} network={network}>
-                {(props) => <Main {...props} />}
-            </WithWalletConnector>
+            <NetworkSelector selected={network} options={[TESTNET, MAINNET]} select={setNetwork} />
+            <WithWalletConnector network={network}>{(props) => <Main {...props} />}</WithWalletConnector>
         </Container>
     );
 }
@@ -77,15 +47,25 @@ function Main(props: WalletConnectionProps) {
         <>
             <Row className="mt-3 mb-3">
                 <Col>
-                    <WalletConnectorButton connectorType="BrowserWallet" connectorName="Browser Wallet" {...props} />
+                    <WalletConnectorButton connectorType={BROWSER_WALLET} connectorName="Browser Wallet" {...props} />
                 </Col>
                 <Col>
-                    <WalletConnectorButton connectorType="WalletConnect" connectorName="Wallet Connect" {...props} />
+                    <WalletConnectorButton connectorType={WALLET_CONNECT} connectorName="WalletConnect" {...props} />
                 </Col>
             </Row>
             <Row className="mt-3 mb-3">
                 <Col>
-                    <WalletConnectionButton {...props} />
+                    <WalletConnectionButton {...props}>
+                        <>
+                            {props.isConnecting && 'Connecting...'}
+                            {!props.isConnecting &&
+                                props.activeConnectorType === BROWSER_WALLET &&
+                                'Connect Browser Wallet'}
+                            {!props.isConnecting &&
+                                props.activeConnectorType === WALLET_CONNECT &&
+                                'Connect Mobile Wallet'}
+                        </>
+                    </WalletConnectionButton>
                 </Col>
             </Row>
             <Row className="mt-3 mb-3">

--- a/samples/contractupdate/src/WalletConnectionButton.tsx
+++ b/samples/contractupdate/src/WalletConnectionButton.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { Alert, Button, Spinner } from 'react-bootstrap';
 import { WalletConnectionProps } from '@concordium/react-components';
 
+interface Props extends WalletConnectionProps {
+    children: JSX.Element;
+}
+
 export function WalletConnectionButton({
     activeConnectorType,
     activeConnector,
@@ -9,16 +13,15 @@ export function WalletConnectionButton({
     activeConnection,
     connectActive,
     isConnecting,
-}: WalletConnectionProps) {
+    children,
+}: Props) {
     return (
         <>
             {activeConnectorError && <Alert variant="danger">Error: {activeConnectorError}.</Alert>}
             {!activeConnectorError && activeConnectorType && !activeConnector && <Spinner />}
             {activeConnector && !activeConnection && (
                 <Button type="button" onClick={connectActive} disabled={isConnecting}>
-                    {isConnecting && 'Connecting...'}
-                    {!isConnecting && activeConnectorType === 'BrowserWallet' && 'Connect Browser Wallet'}
-                    {!isConnecting && activeConnectorType === 'WalletConnect' && 'Connect Mobile Wallet'}
+                    {children}
                 </Button>
             )}
         </>

--- a/samples/contractupdate/src/config.ts
+++ b/samples/contractupdate/src/config.ts
@@ -1,0 +1,37 @@
+import { SignClientTypes } from '@walletconnect/types';
+import {
+    BrowserWalletConnector,
+    Network,
+    ephemeralConnectorType,
+    WalletConnectConnector,
+} from '@concordium/react-components';
+
+const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
+const MAINNET_GENESIS_BLOCK_HASH = '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
+
+export const TESTNET: Network = {
+    name: 'testnet',
+    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
+    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
+    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
+};
+export const MAINNET: Network = {
+    name: 'mainnet',
+    genesisHash: MAINNET_GENESIS_BLOCK_HASH,
+    jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software',
+    ccdScanBaseUrl: 'https://ccdscan.io',
+};
+
+const WALLET_CONNECT_PROJECT_ID = '76324905a70fe5c388bab46d3e0564dc';
+const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
+    projectId: WALLET_CONNECT_PROJECT_ID,
+    metadata: {
+        name: 'Contract Update',
+        description: 'Example dApp for the performing an update on a contract.',
+        url: '#',
+        icons: ['https://walletconnect.com/walletconnect-logo.png'],
+    },
+};
+
+export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
+export const WALLET_CONNECT = ephemeralConnectorType(WalletConnectConnector.create.bind(this, WALLET_CONNECT_OPTS));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,7 +1552,6 @@ __metadata:
     "@tsconfig/recommended": ^1.0.1
     "@types/node": ^18.11.17
     "@types/react": ^18
-    "@walletconnect/types": ^2.1.4
     prettier: 2.8.1
     typescript: ^4.9.4
   peerDependencies:


### PR DESCRIPTION
## Purpose

Decouple component `WithWalletConnector` from concrete `WalletConnector` implementations by constructing instances from the application. This allows the component to accept custom connector implementations as it only refers to the shared interface. In particular, it means that the component no longer expects the misfitting `walletConnectOpts` prop. It also allows the application to control the lifecycle of the connectors.

## Changes

Make `ConnectorType` an interface instead of a string enum. This interface controls the activation/deactivation lifecycle of the connectors, including construction of new connector instances. Two implementations of this interface are included, both of which are implemented as functions: One that only keeps connectors alive while they're active (`ephemeralConnectorType`; closest to the current behavior) and one that allows them to be reactivated (`persistentConnectorType`).

The default way to initialize the connector type from the application is

```typescript
export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
export const WALLET_CONNECT = ephemeralConnectorType(WalletConnectConnector.create.bind(this, WALLET_CONNECT_OPTS));
```

These constants should be drop-in replacements for current strings `"BrowserWallet"` and `"WalletConnect"`. The method`WithWalletConnectorProps.disconnectActive` is no longer relevant and has been removed. These are the only breaking changes introduced by this PR.

The component now also tracks state for all live connections, not just the active one: Connected accounts and genesis hashes for nonactive connections are exposed for lookup in the new fields `props.connectedAccounts` and `props.genesisHashes`.