### PR TITLE
Add ability to ping connections

### DIFF
--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -73,6 +73,10 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         return this;
     }
 
+    async ping() {
+        return undefined;
+    }
+
     async getConnectedAccount() {
         return this.client.getMostRecentlySelectedAccount();
     }

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -182,6 +182,11 @@ export class WalletConnectConnection implements WalletConnection {
         return this.connector;
     }
 
+    async ping() {
+        const {topic} = this.session;
+        await this.connector.client.ping({ topic });
+    }
+
     async getConnectedAccount() {
         // We're only expecting a single account to be connected.
         const fullAddress = this.session.namespaces[WALLET_CONNECT_SESSION_NAMESPACE].accounts[0];

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -30,6 +30,11 @@ export interface WalletConnection {
     getConnector(): WalletConnector;
 
     /**
+     * Ping the connection.
+     */
+    ping(): Promise<void>
+
+    /**
      * @return The account that the wallet currently associates with this connection.
      */
     getConnectedAccount(): Promise<string | undefined>;


### PR DESCRIPTION
## Purpose

Enable the application to ping connections to ensure that they're alive.

## Changes

Add method `ping` in `WalletConnection`. The `BrowserWallet` implementation is a noop, in `WalletConnect` it delegates to the ping method of the underlying client.

Resolves #7.