### PR TITLE
wallet-connectors: Add event handler for newly established connection 

### DIFF
--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -278,7 +278,9 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
         }
     };
 
-    onDisconnect = (connection: WalletConnection) => {
+    onConnected = () => undefined;
+
+    onDisconnected = (connection: WalletConnection) => {
         console.debug("WithWalletConnector: calling 'onDisconnect'", { connection, state: this.state });
         const { activeConnection } = this.state;
         // Ignore event on connections other than the active one.

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -59,6 +59,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         if (!account) {
             throw new Error('Browser Wallet connection failed');
         }
+        this.delegate.onConnected(this);
         return this;
     }
 
@@ -93,7 +94,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         // (which stays in the browser window's global state)
         // such that it doesn't interfere with a future reconnection.
         this.client.removeAllListeners();
-        this.delegate.onDisconnect(this);
+        this.delegate.onDisconnected(this);
     }
 
     async signAndSendTransaction(

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -317,8 +317,7 @@ export class WalletConnectConnector implements WalletConnector {
                 console.error(`WalletConnect event 'session_delete' received for unknown topic '${topic}'.`);
                 return;
             }
-            this.connections.delete(topic);
-            delegate.onDisconnect(connection);
+            this.onDisconnect(connection);
         });
     }
 

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -349,12 +349,13 @@ export class WalletConnectConnector implements WalletConnector {
         const rpcClient = new JsonRpcClient(new HttpProvider(this.network.jsonRpcUrl));
         const connection = new WalletConnectConnection(this, rpcClient, chainId, session);
         this.connections.set(session.topic, connection);
+        this.delegate.onConnected(connection);
         return connection;
     }
 
     onDisconnect(connection: WalletConnectConnection) {
         this.connections.delete(connection.session.topic);
-        this.delegate.onDisconnect(connection);
+        this.delegate.onDisconnected(connection);
     }
 
     async getConnections() {

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -170,10 +170,16 @@ export interface WalletConnectionDelegate {
     onAccountChanged(connection: WalletConnection, address: string | undefined): void;
 
     /**
+     * Notification that the given {@link WalletConnection} has been established.
+     * @param connection Affected connection.
+     */
+    onConnected(connection: WalletConnection): void;
+
+    /**
      * Notification that the given {@link WalletConnection} has been disconnected.
      * @param connection Affected connection.
      */
-    onDisconnect(connection: WalletConnection): void;
+    onDisconnected(connection: WalletConnection): void;
 }
 
 /**


### PR DESCRIPTION
The disconnect handler has been renamed for consistence.

It's intended future usage is to allow applications using react-components to connect directly using `WalletConnector.connect` instead of having to use the function exposed by the `WithWalletConnector` component. The component will then be notified of the connection and register it appropriately.