### PR TITLE
Minor cleanup

### DIFF
--- a/packages/react-components/src/useContractSelector.ts
+++ b/packages/react-components/src/useContractSelector.ts
@@ -83,7 +83,7 @@ export interface ContractSelector {
     /**
      * The selected contract info, if available.
      * Is undefined if there isn't any index to look up, during lookup, or the lookup failed.
-     * In the latter case {@link validationError} will be non-empty.
+     * In the latter case {@link error} will be non-empty.
      */
     selected: Info | undefined;
 
@@ -95,8 +95,7 @@ export interface ContractSelector {
     /**
      * Error parsing the input string or RPC error looking up the contract.
      */
-    // TODO Rename as it isn't only a validation error.
-    validationError: string;
+    error: string;
 }
 
 /**
@@ -108,20 +107,20 @@ export interface ContractSelector {
 export function useContractSelector(rpc: JsonRpcClient | undefined, input: string): ContractSelector {
     const [selected, setSelected] = useState<Info>();
     const [isLoading, setIsLoading] = useState(false);
-    const [validationError, setValidationError] = useState('');
+    const [error, setError] = useState('');
     useEffect(() => {
         setSelected(undefined);
-        setValidationError('');
+        setError('');
         if (rpc && input) {
             setIsLoading(true);
             loadContract(rpc, input)
                 .then(setSelected)
                 .catch((err) => {
-                    setValidationError((err as Error).message);
+                    setError((err as Error).message);
                     setSelected(undefined); // prevents race condition against an ongoing successful query
                 })
                 .finally(() => setIsLoading(false));
         }
     }, [rpc, input]);
-    return { selected, isLoading, validationError };
+    return { selected, isLoading, error };
 }

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -183,7 +183,7 @@ export class WalletConnectConnection implements WalletConnection {
     }
 
     async ping() {
-        const {topic} = this.session;
+        const { topic } = this.session;
         await this.connector.client.ping({ topic });
     }
 

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -32,7 +32,7 @@ export interface WalletConnection {
     /**
      * Ping the connection.
      */
-    ping(): Promise<void>
+    ping(): Promise<void>;
 
     /**
      * @return The account that the wallet currently associates with this connection.

--- a/samples/contractupdate/package.json
+++ b/samples/contractupdate/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "dependencies": {
         "@concordium/react-components": "0.1.0",
-        "@concordium/wallet-connectors": "0.1.0",
         "bootstrap": "^5.2.3",
         "buffer": "^6.0.3",
         "is-base64": "^1.1.0",

--- a/samples/contractupdate/src/App.tsx
+++ b/samples/contractupdate/src/App.tsx
@@ -1,4 +1,4 @@
-import { Network, WalletConnection } from '@concordium/wallet-connectors';
+import { Network, WalletConnection } from '@concordium/react-components';
 import { Col, Form, Row, Spinner } from 'react-bootstrap';
 import { useContractSelector } from '@concordium/react-components';
 import { ContractDetails } from './ContractDetails';
@@ -28,10 +28,10 @@ export function App({ network, connection, connectedAccount }: Props) {
                                 placeholder="Address (index)"
                                 value={input}
                                 onChange={(e) => setInput(e.currentTarget.value)}
-                                isInvalid={Boolean(contract.validationError)}
+                                isInvalid={Boolean(contract.error)}
                                 autoFocus
                             />
-                            <Form.Control.Feedback type="invalid">{contract.validationError}</Form.Control.Feedback>
+                            <Form.Control.Feedback type="invalid">{contract.error}</Form.Control.Feedback>
                         </Col>
                     </Form.Group>
                     {contract.isLoading && <Spinner animation="border" />}

--- a/samples/contractupdate/src/ConnectedAccount.tsx
+++ b/samples/contractupdate/src/ConnectedAccount.tsx
@@ -1,4 +1,4 @@
-import { Network, WalletConnection, withJsonRpcClient } from '@concordium/wallet-connectors';
+import { Network, WalletConnection, withJsonRpcClient } from '@concordium/react-components';
 import { useEffect, useState } from 'react';
 import { AccountInfo } from '@concordium/web-sdk';
 import { Alert } from 'react-bootstrap';

--- a/samples/contractupdate/src/ContractInvoker.tsx
+++ b/samples/contractupdate/src/ContractInvoker.tsx
@@ -2,7 +2,7 @@ import { Info } from '@concordium/react-components';
 import isBase64 from 'is-base64';
 import React, { ChangeEvent, Dispatch, useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Col, Dropdown, Form, Row } from 'react-bootstrap';
-import { Network, WalletConnection } from '@concordium/wallet-connectors';
+import { Network, WalletConnection } from '@concordium/react-components';
 import { AccountAddress, AccountTransactionType, CcdAmount } from '@concordium/web-sdk';
 import { err, ok, Result, ResultAsync } from 'neverthrow';
 import { useContractSchemaRpc } from './useContractSchemaRpc';

--- a/samples/contractupdate/src/NetworkSelector.tsx
+++ b/samples/contractupdate/src/NetworkSelector.tsx
@@ -1,5 +1,5 @@
 import { Dropdown } from 'react-bootstrap';
-import { Network } from '@concordium/wallet-connectors';
+import { Network } from '@concordium/react-components';
 import { useCallback } from 'react';
 
 interface Props {

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Col, Container, Row } from 'react-bootstrap';
-import { Network, withJsonRpcClient } from '@concordium/wallet-connectors';
+import { Network, withJsonRpcClient } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
 import { WalletConnectionProps, WithWalletConnector } from '@concordium/react-components';
 import { WalletConnectionButton } from './WalletConnectionButton';

--- a/samples/contractupdate/src/useContractSchemaRpc.ts
+++ b/samples/contractupdate/src/useContractSchemaRpc.ts
@@ -1,6 +1,6 @@
 import { err, ok, Result, ResultAsync } from 'neverthrow';
 import { Buffer } from 'buffer/';
-import { WalletConnection, withJsonRpcClient } from '@concordium/wallet-connectors';
+import { WalletConnection, withJsonRpcClient } from '@concordium/react-components';
 import { Info } from '@concordium/react-components';
 import { useEffect, useState } from 'react';
 import { ModuleReference } from '@concordium/web-sdk';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5328,7 +5328,6 @@ __metadata:
   resolution: "concordium-dapp-contractupdate@workspace:samples/contractupdate"
   dependencies:
     "@concordium/react-components": 0.1.0
-    "@concordium/wallet-connectors": 0.1.0
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^13.0.0
     "@testing-library/user-event": ^13.2.1


### PR DESCRIPTION
Changes extracted from [the refactor PR](https://github.com/Concordium/concordium-dapp-libraries/pull/6) that weren't actually relevant to that PR:

- `ContractSelector`: Renamed `validationError` to `error` to reflect that it isn't necessarily validation error.
- Sample dapp: Removed direct dependency on `@concordium/wallet-connectors` as `react-components` re-exports the library (see https://github.com/Concordium/concordium-dapp-libraries/commit/f571d59feee65581ea1750b3126aec4389281a5a) and migrate imports.