### PR TITLE
contractupdate: Add indicator when waiting for approval

### DIFF
--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -371,7 +371,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
                         if (state.activeConnector !== activeConnector) {
                             return state;
                         }
-                        return { ...state, activeConnectorError: (err as Error).message || (err as string) };
+                        return { ...state, activeConnectorError: (err as Error).message};
                     });
                 })
                 .finally(() => {

--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -371,7 +371,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
                         if (state.activeConnector !== activeConnector) {
                             return state;
                         }
-                        return { ...state, activeConnectorError: (err as Error).message };
+                        return { ...state, activeConnectorError: (err as Error).message || (err as string) };
                     });
                 })
                 .finally(() => {

--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -371,7 +371,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
                         if (state.activeConnector !== activeConnector) {
                             return state;
                         }
-                        return { ...state, activeConnectorError: (err as Error).message};
+                        return { ...state, activeConnectorError: (err as Error).message };
                     });
                 })
                 .finally(() => {

--- a/samples/contractupdate/src/ContractInvoker.tsx
+++ b/samples/contractupdate/src/ContractInvoker.tsx
@@ -78,9 +78,11 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
         [contractParamsResult, schemaResult, amountResult]
     );
 
+    const [isAwaitingApproval, setIsAwaitingApproval] = useState(false);
     const [submittedTxHash, setSubmittedTxHash] = useState<Result<string, string>>();
     const submit = useCallback(() => {
         if (connectedAccount) {
+            setIsAwaitingApproval(true);
             inputResult
                 .asyncAndThen(([params, schema, amount]) =>
                     ResultAsync.fromPromise(
@@ -99,7 +101,10 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
                         (e) => (e as Error).message
                     )
                 )
-                .then(setSubmittedTxHash);
+                .then(r => {
+                    setSubmittedTxHash(r);
+                    setIsAwaitingApproval(false);
+                });
         }
     }, [connection, connectedAccount, contract, selectedMethodIndex, inputResult]);
     return (
@@ -207,8 +212,9 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
                 </Form.Group>
                 <Row>
                     <Col>
-                        <Button onClick={submit} disabled={inputResult.isErr()}>
-                            Submit
+                        <Button onClick={submit} disabled={isAwaitingApproval || inputResult.isErr()}>
+                            {isAwaitingApproval && 'Waiting for approval...'}
+                            {!isAwaitingApproval && 'Submit'}
                         </Button>
                     </Col>
                 </Row>


### PR DESCRIPTION
## Purpose

Make it visible in the dApp that it's waiting for the use to approve an action in the wallet. And prevent the user from submitting again until the first action is approved or rejected.

## Changes

Add waiting indicator state and use it to disable the submit button.

Resolves #14.