### PR TITLE
Add utility function for extracting string from error

### DIFF
--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import { Network, WalletConnection, WalletConnectionDelegate, WalletConnector } from '@concordium/wallet-connectors';
+import { errorString } from './error';
 
 /**
  * Activation/deactivation controller of a given connector type.
@@ -260,7 +261,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
                     if (state.activeConnectorType !== type) {
                         return state;
                     }
-                    return { ...state, activeConnectorError: (err as Error).message };
+                    return { ...state, activeConnectorError: errorString(err) };
                 })
             );
         }
@@ -276,7 +277,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
                         if (state.activeConnectorType !== type) {
                             return state;
                         }
-                        return { ...state, activeConnectorError: (err as Error).message };
+                        return { ...state, activeConnectorError: errorString(err) };
                     })
                 );
         }
@@ -371,7 +372,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
                         if (state.activeConnector !== activeConnector) {
                             return state;
                         }
-                        return { ...state, activeConnectorError: (err as Error).message };
+                        return { ...state, activeConnectorError: errorString(err) };
                     });
                 })
                 .finally(() => {

--- a/packages/react-components/src/error.ts
+++ b/packages/react-components/src/error.ts
@@ -1,0 +1,3 @@
+export function errorString(err: any): string {
+    return (err as Error).message || (err as string);
+}

--- a/packages/react-components/src/useContractSelector.ts
+++ b/packages/react-components/src/useContractSelector.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { AccountAddress, CcdAmount, JsonRpcClient } from '@concordium/web-sdk';
+import { errorString } from './error';
 
 /**
  * Data and state of a smart contract.
@@ -116,7 +117,7 @@ export function useContractSelector(rpc: JsonRpcClient | undefined, input: strin
             loadContract(rpc, input)
                 .then(setSelected)
                 .catch((err) => {
-                    setError((err as Error).message);
+                    setError(errorString(err));
                     setSelected(undefined); // prevents race condition against an ongoing successful query
                 })
                 .finally(() => setIsLoading(false));

--- a/samples/contractupdate/src/ContractInvoker.tsx
+++ b/samples/contractupdate/src/ContractInvoker.tsx
@@ -6,6 +6,7 @@ import { Network, WalletConnection } from '@concordium/react-components';
 import { AccountAddress, AccountTransactionType, CcdAmount } from '@concordium/web-sdk';
 import { err, ok, Result, ResultAsync } from 'neverthrow';
 import { useContractSchemaRpc } from './useContractSchemaRpc';
+import { errorString } from './util';
 
 interface ContractParamEntry {
     name: string;
@@ -96,7 +97,7 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
                             params,
                             schema.schema
                         ),
-                        (e) => (e as Error).message
+                        (e) => errorString(e)
                     )
                 )
                 .then(setSubmittedTxHash);

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -8,6 +8,7 @@ import { ConnectedAccount } from './ConnectedAccount';
 import { App } from './App';
 import { NetworkSelector } from './NetworkSelector';
 import { BROWSER_WALLET, MAINNET, TESTNET, WALLET_CONNECT } from './config';
+import { errorString } from './util';
 
 export default function Root() {
     const [network, setNetwork] = useState(TESTNET);
@@ -38,7 +39,7 @@ function Main(props: WalletConnectionProps) {
                 })
                 .catch((err) => {
                     setRpcGenesisHash(undefined);
-                    setRpcError((err as Error).message);
+                    setRpcError(errorString(err));
                 });
         }
     }, [activeConnection, activeConnectionGenesisHash, network]);

--- a/samples/contractupdate/src/useContractSchemaRpc.ts
+++ b/samples/contractupdate/src/useContractSchemaRpc.ts
@@ -40,7 +40,7 @@ export function useContractSchemaRpc(connection: WalletConnection, contract: Inf
     useEffect(() => {
         ResultAsync.fromPromise(
             withJsonRpcClient(connection, (rpc) => rpc.getModuleSource(new ModuleReference(contract.moduleRef))),
-            (e) => errorString(e),
+            (e) => errorString(e)
         )
             .andThen((r) => {
                 if (!r || r.length < 12) {

--- a/samples/contractupdate/src/useContractSchemaRpc.ts
+++ b/samples/contractupdate/src/useContractSchemaRpc.ts
@@ -3,6 +3,7 @@ import { Buffer } from 'buffer/';
 import { WalletConnection, withJsonRpcClient } from '@concordium/react-components';
 import { Info } from '@concordium/react-components';
 import { useEffect, useState } from 'react';
+import { errorString } from './util';
 import { ModuleReference } from '@concordium/web-sdk';
 
 export interface SchemaRpcResult {
@@ -39,7 +40,7 @@ export function useContractSchemaRpc(connection: WalletConnection, contract: Inf
     useEffect(() => {
         ResultAsync.fromPromise(
             withJsonRpcClient(connection, (rpc) => rpc.getModuleSource(new ModuleReference(contract.moduleRef))),
-            (e) => (e as Error).message
+            (e) => errorString(e),
         )
             .andThen((r) => {
                 if (!r || r.length < 12) {
@@ -48,7 +49,7 @@ export function useContractSchemaRpc(connection: WalletConnection, contract: Inf
                 if (r.length < 12) {
                     return err('module source is too short');
                 }
-                return ResultAsync.fromPromise(WebAssembly.compile(r.slice(12)), (e) => (e as Error).message);
+                return ResultAsync.fromPromise(WebAssembly.compile(r.slice(12)), (e) => errorString(e));
             })
             .andThen(findSchema)
             .then(setResult);

--- a/samples/contractupdate/src/util.ts
+++ b/samples/contractupdate/src/util.ts
@@ -1,0 +1,3 @@
+export function errorString(err: any): string {
+    return (err as Error).message || (err as string);
+}

--- a/samples/contractupdate/tsconfig.json
+++ b/samples/contractupdate/tsconfig.json
@@ -16,5 +16,7 @@
         "noEmit": true,
         "jsx": "react-jsx"
     },
-    "include": ["./src"]
+    "include": [
+      "./src",
+    ]
 }

--- a/samples/contractupdate/tsconfig.json
+++ b/samples/contractupdate/tsconfig.json
@@ -16,7 +16,5 @@
         "noEmit": true,
         "jsx": "react-jsx"
     },
-    "include": [
-      "./src",
-    ]
+    "include": ["./src"]
 }


### PR DESCRIPTION
## Purpose

Ensure that non-`Error` exceptions don't go undetected.

## Changes

Compared to the usual strategy of using `(err as Error).message`, this function adds a fallback to just treating the value as a string. This avoids errors that aren't actually of type `Error` to be masked as described in https://concordium.atlassian.net/browse/CBW-780.