### PR TITLE
wallet-connectors: Improve 'getConnections'

### DIFF
--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `WalletConnectionDelegate`: Added `onConnected` event method and renamed `onDisconnect` to `onDisconnected`
     for consistency.
--   `WalletConnect`: Reorder constructor parameters to accommodate changes in `@concordium/react-components`.
+-   `WalletConnect`: Reordered constructor parameters to accommodate changes in `@concordium/react-components`.
+-   `WalletConnector`: Made `getConnections` non-async.
 
 ## [0.1.0] - 2023-01-17
 

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -20,6 +20,8 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
 
     readonly delegate: WalletConnectionDelegate;
 
+    isConnected = false;
+
     /**
      * Construct a new instance.
      *
@@ -59,15 +61,13 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         if (!account) {
             throw new Error('Browser Wallet connection failed');
         }
+        this.isConnected = true;
         this.delegate.onConnected(this);
         return this;
     }
 
-    async getConnections() {
-        // Defining "connected" as the presence of a connected account.
-        // TODO Would be more stable to base on availability of RPC client?
-        const account = await this.getConnectedAccount();
-        return account ? [this] : [];
+    getConnections() {
+        return this.isConnected ? [this] : [];
     }
 
     getConnector(): WalletConnector {
@@ -97,6 +97,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         // This "disconnect" only ensures that we stop interacting with the client
         // (which stays in the browser window's global state)
         // such that it doesn't interfere with a future reconnection.
+        this.isConnected = false;
         this.client.removeAllListeners();
         this.delegate.onDisconnected(this);
     }

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -363,7 +363,7 @@ export class WalletConnectConnector implements WalletConnector {
         this.delegate.onDisconnected(connection);
     }
 
-    async getConnections() {
+    getConnections() {
         return Array.from(this.connections.values());
     }
 

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -212,7 +212,7 @@ export interface WalletConnector {
      * Get a list of all connections initiated by this connector that have not been disconnected.
      * @return A promise resolving to all the connector's connections.
      */
-    getConnections(): Promise<WalletConnection[]>;
+    getConnections(): WalletConnection[];
 
     /**
      * Ensure that all connections initiated by this connector are disconnected


### PR DESCRIPTION
## Purpose

Ensure that `BrowserWallet.getConnections` only returns a connection if the user has asked for it to be "connected".

## Changes

Add a field to `BrowserWallet` to indicate whether the connection is "established". Using the presence of an account like before is not enough as the account could be available on a fresh page load. But as the delegate's `onConnected` method isn't called until `connect` is called. This means that the account would be missing in any state maintained by the delegate.

This solution also allows the connection to be marked as disconnected later on.

As no implementations of `getConnections` are really asynchronous anymore, we also change the interface method to non-async. This makes sense as connectors really should be able to know about their connections directly.