### PR TITLE
wallet-connectors: Add account to 'onConnected'

### DIFF
--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -289,33 +289,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
         console.debug("WithWalletConnector: calling 'setActiveConnection'", { connection, state: this.state });
         // NOTE As described in the docstring of `State.activeConnection`,
         //      setting the active connection doesn't imply that the active connector should be set as well.
-        this.setState((state) => ({
-            ...state,
-            activeConnection: connection,
-            connectedAccounts: updateMapEntry(state.connectedAccounts, state.activeConnection, undefined),
-        }));
-        if (connection) {
-            connection.getConnectedAccount().then((connectedAccount) => {
-                // This might be redundant for existing connections as the delegate already listens for account change events.
-                // But for new connections we might get the account from the connector without having received any events.
-                console.log('WithWalletConnector: updating active connection and connected account state', {
-                    connection,
-                    connectedAccount,
-                });
-
-                // Don't set connected accounts if the active connection changed while loading the accounts.
-                this.setState((state) => {
-                    const { activeConnection, connectedAccounts } = state;
-                    if (activeConnection !== connection) {
-                        return state;
-                    }
-                    return {
-                        ...state,
-                        connectedAccounts: updateMapEntry(connectedAccounts, connection, connectedAccount),
-                    };
-                });
-            });
-        }
+        this.setState({ activeConnection: connection });
     };
 
     onAccountChanged = (connection: WalletConnection, address: string | undefined) => {
@@ -334,7 +308,10 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
         }));
     };
 
-    onConnected = () => undefined;
+    onConnected = (connection: WalletConnection, address: string | undefined) => {
+        console.debug("WithWalletConnector: calling 'onConnected'", { connection, state: this.state });
+        this.onAccountChanged(connection, address);
+    };
 
     onDisconnected = (connection: WalletConnection) => {
         console.debug("WithWalletConnector: calling 'onDisconnect'", { connection, state: this.state });

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `WalletConnectionDelegate`: Added `onConnected` event method and renamed `onDisconnect` to `onDisconnected`
     for consistency.
 -   `WalletConnect`: Reorder constructor parameters to accommodate changes in `@concordium/react-components`.
+-   `WalletConnection`: Removed `getConnectedAccount` (the implementation methods stay but are no longer forced to be async).
 
 ## [0.1.0] - 2023-01-17
 

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -77,6 +77,9 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         return undefined;
     }
 
+    /**
+     * @return The account that the wallet currently associates with this connection.
+     */
     async getConnectedAccount() {
         return this.client.getMostRecentlySelectedAccount();
     }

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -58,7 +58,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         if (!account) {
             throw new Error('Browser Wallet connection failed');
         }
-        this.delegate.onConnected(this);
+        this.delegate.onConnected(this, account);
         return this;
     }
 

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -187,10 +187,20 @@ export class WalletConnectConnection implements WalletConnection {
         await this.connector.client.ping({ topic });
     }
 
-    async getConnectedAccount() {
+    /**
+     * Non-async variant of {@link getConnectedAccount}.
+     * The async version is a simple wrapper around this one and
+     * only exists to satisfy the {@link WalletConnection} interface.
+     * So prefer this method when interacting with this concrete type.
+     */
+    getConnectedAccount_() {
         // We're only expecting a single account to be connected.
         const fullAddress = this.session.namespaces[WALLET_CONNECT_SESSION_NAMESPACE].accounts[0];
         return fullAddress.substring(fullAddress.lastIndexOf(':') + 1);
+    }
+
+    async getConnectedAccount() {
+        return this.getConnectedAccount_();
     }
 
     getJsonRpcClient() {
@@ -354,7 +364,7 @@ export class WalletConnectConnector implements WalletConnector {
         const rpcClient = new JsonRpcClient(new HttpProvider(this.network.jsonRpcUrl));
         const connection = new WalletConnectConnection(this, rpcClient, chainId, session);
         this.connections.set(session.topic, connection);
-        this.delegate.onConnected(connection);
+        this.delegate.onConnected(connection, connection.getConnectedAccount_());
         return connection;
     }
 

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -35,11 +35,6 @@ export interface WalletConnection {
     ping(): Promise<void>;
 
     /**
-     * @return The account that the wallet currently associates with this connection.
-     */
-    getConnectedAccount(): Promise<string | undefined>;
-
-    /**
      * Returns a JSON-RPC client that is ready to perform requests against some Concordium Node connected to network/chain
      * that the connected account lives on.
      *

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -177,8 +177,9 @@ export interface WalletConnectionDelegate {
     /**
      * Notification that the given {@link WalletConnection} has been established.
      * @param connection Affected connection.
+     * @param address The address of the initially connected account.
      */
-    onConnected(connection: WalletConnection): void;
+    onConnected(connection: WalletConnection, address: string | undefined): void;
 
     /**
      * Notification that the given {@link WalletConnection} has been disconnected.


### PR DESCRIPTION
The account is usually (as in all current instances) known at the time that the connection has been established. Instead of the application having to poll it (asynchronously) from the connection, we might as well pass it up front.