### PR TITLE
wallet-connectors: Bump version for release

### DIFF
--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-03-13
+
 ### Changed
--   `WalletConnect`: Add `sign_message` to `requiredNamespaces` when `connect`.
+
+-   `WalletConnect`: Add `sign_message` to `requiredNamespaces` in the call to `connect`.
 
 ## [0.2.0] - 2023-02-06
 

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/wallet-connectors",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Utility interface for dApps to interact with wallets without depending on the underlying protocol and implementations for Concordium Browser Wallet and Wallet Connect v2.",
     "author": "Concordium Software",
     "license": "Apache-2.0",


### PR DESCRIPTION
This is a patch release that includes a small fix. It also serves as a test to https://github.com/Concordium/concordium-dapp-libraries/pull/23.