### PR TITLE
react-components: Bump wallet-connectors dependency

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-03-17
+
+### Changed
+
+-   Bump and unpin dependency to `wallet-connectors`.
+
 ## [0.2.0] - 2023-02-06
 
 ### Added

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -20,7 +20,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/wallet-connectors": "0.2.0"
+        "@concordium/wallet-connectors": "^0.2.1"
     },
     "devDependencies": {
         "@tsconfig/recommended": "^1.0.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/react-components",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Utility library of React components for building dApps that interact with the Concordium blockchain.",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,7 +1548,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/react-components@workspace:packages/react-components"
   dependencies:
-    "@concordium/wallet-connectors": 0.2.0
+    "@concordium/wallet-connectors": ^0.2.1
     "@tsconfig/recommended": ^1.0.1
     "@types/node": ^18.11.17
     "@types/react": ^18
@@ -1566,18 +1566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/wallet-connectors@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@concordium/wallet-connectors@npm:0.2.0"
-  dependencies:
-    "@concordium/browser-wallet-api-helpers": ^2.0.0
-    "@walletconnect/qrcode-modal": ^1.8.0
-    "@walletconnect/sign-client": ^2.1.4
-  checksum: 262af06d5d09e452d307022c66a1d303d8aad1c21f6bfeb6bc24acb4f102bc5deb492de7e093612b05a6f67a9031f6801089f6aec671d0ae7eb26d7ead9cf528
-  languageName: node
-  linkType: hard
-
-"@concordium/wallet-connectors@workspace:packages/wallet-connectors":
+"@concordium/wallet-connectors@^0.2.1, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
   version: 0.0.0-use.local
   resolution: "@concordium/wallet-connectors@workspace:packages/wallet-connectors"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,7 +1544,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/react-components@0.2.0, @concordium/react-components@workspace:packages/react-components":
+"@concordium/react-components@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@concordium/react-components@npm:0.2.0"
+  dependencies:
+    "@concordium/wallet-connectors": 0.2.0
+  peerDependencies:
+    react: ^18
+  checksum: b4141037d2f38d289362ca124369d7d61b9ec5260ca895d57bf6d5823027c901e96943f27261b2813ccdfaae9dbeecaf35a1a37492e146ea6d32fc358486f4be
+  languageName: node
+  linkType: hard
+
+"@concordium/react-components@workspace:packages/react-components":
   version: 0.0.0-use.local
   resolution: "@concordium/react-components@workspace:packages/react-components"
   dependencies:
@@ -1579,6 +1590,17 @@ __metadata:
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
+
+"@concordium/wallet-connectors@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@concordium/wallet-connectors@npm:0.2.0"
+  dependencies:
+    "@concordium/browser-wallet-api-helpers": ^2.0.0
+    "@walletconnect/qrcode-modal": ^1.8.0
+    "@walletconnect/sign-client": ^2.1.4
+  checksum: 262af06d5d09e452d307022c66a1d303d8aad1c21f6bfeb6bc24acb4f102bc5deb492de7e093612b05a6f67a9031f6801089f6aec671d0ae7eb26d7ead9cf528
+  languageName: node
+  linkType: hard
 
 "@concordium/web-sdk@npm:^3.2.0":
   version: 3.2.0


### PR DESCRIPTION
The version was pinned as it didn't have a `^`. The version is now unpinned to allow patch upgrades.