### PR TITLE
wallet-connectors: Don't stringify 'signMessage' result

### DIFF
--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   `WalletConnect`: Remove incorrect stringification of `signMessage` result.
+
 ## [0.2.1] - 2023-03-13
 
 ### Changed

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -244,7 +244,7 @@ export class WalletConnectConnection implements WalletConnection {
             },
             chainId: this.chainId,
         });
-        return JSON.stringify(signature) as AccountTransactionSignature;
+        return signature as AccountTransactionSignature;
     }
 
     async disconnect() {


### PR DESCRIPTION
It's unclear why this was done this way but it's definitely wrong.