### PR TITLE
Add `SignMessageObject` to `signMessage` function

### DIFF
--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   Adds support for signing arbitrary data with signMessage.
 -   Added exported constant `CONCORDIUM_WALLET_CONNECT_PROJECT_ID` that dApps may use when connecting to a Concordium mobile wallet.
 
 ### Changed

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -20,7 +20,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/browser-wallet-api-helpers": "^2.0.0",
+        "@concordium/browser-wallet-api-helpers": "^2.4.0",
         "@walletconnect/qrcode-modal": "^1.8.0",
         "@walletconnect/sign-client": "^2.1.4"
     },

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -1,4 +1,4 @@
-import { detectConcordiumProvider, WalletApi } from '@concordium/browser-wallet-api-helpers';
+import { detectConcordiumProvider, WalletApi, SignMessageObject } from '@concordium/browser-wallet-api-helpers';
 import {
     AccountTransactionPayload,
     AccountTransactionSignature,
@@ -122,7 +122,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         return this.client.sendTransaction(accountAddress, type, payload);
     }
 
-    async signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature> {
+    async signMessage(accountAddress: string, message: string | SignMessageObject): Promise<AccountTransactionSignature> {
         return this.client.signMessage(accountAddress, message);
     }
 }

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -1,4 +1,4 @@
-import { detectConcordiumProvider, WalletApi, SignMessageObject } from '@concordium/browser-wallet-api-helpers';
+import { detectConcordiumProvider, WalletApi, SignMessageObject, SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
 import {
     AccountTransactionPayload,
     AccountTransactionSignature,
@@ -108,7 +108,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         accountAddress: string,
         type: AccountTransactionType,
         payload: AccountTransactionPayload,
-        parameters?: Record<string, unknown>,
+        parameters?: SmartContractParameters,
         schema?: string,
         schemaVersion?: SchemaVersion
     ): Promise<string> {

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -1,7 +1,7 @@
 import SignClient from '@walletconnect/sign-client';
 import QRCodeModal from '@walletconnect/qrcode-modal';
 import { ISignClient, SessionTypes, SignClientTypes } from '@walletconnect/types';
-import { SignMessageObject } from '@concordium/browser-wallet-api-helpers';
+import { SignMessageObject, SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
 import {
     AccountTransactionPayload,
     AccountTransactionSignature,
@@ -85,7 +85,7 @@ function accountTransactionPayloadToJson(data: AccountTransactionPayload) {
 function encodePayloadParameters(
     type: AccountTransactionType,
     payload: AccountTransactionPayload,
-    parameters?: Record<string, unknown>,
+    parameters?: SmartContractParameters,
     schema?: string,
     schemaVersion?: SchemaVersion
 ) {
@@ -205,7 +205,7 @@ export class WalletConnectConnection implements WalletConnection {
         accountAddress: string,
         type: AccountTransactionType,
         payload: AccountTransactionPayload,
-        parameters?: Record<string, unknown>,
+        parameters?: SmartContractParameters,
         schema?: string,
         schemaVersion?: SchemaVersion
     ) {

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -1,6 +1,7 @@
 import SignClient from '@walletconnect/sign-client';
 import QRCodeModal from '@walletconnect/qrcode-modal';
 import { ISignClient, SessionTypes, SignClientTypes } from '@walletconnect/types';
+import { SignMessageObject } from '@concordium/browser-wallet-api-helpers';
 import {
     AccountTransactionPayload,
     AccountTransactionSignature,
@@ -234,7 +235,7 @@ export class WalletConnectConnection implements WalletConnection {
         }
     }
 
-    async signMessage(accountAddress: string, message: string) {
+    async signMessage(accountAddress: string, message: string | SignMessageObject) {
         const params = { message };
         const signature = await this.connector.client.request({
             topic: this.session.topic,

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -7,6 +7,7 @@ import {
     SchemaVersion,
     UpdateContractPayload,
 } from '@concordium/web-sdk';
+import { SignMessageObject } from '@concordium/browser-wallet-api-helpers';
 
 // Copied from 'wallet-api-types.ts' in 'browser-wallet-api-helpers' as it isn't exported.
 type SendTransactionPayload =
@@ -103,7 +104,7 @@ export interface WalletConnection {
      * @param message The message to sign.
      * @return A promise for the signatures of the message.
      */
-    signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature>;
+    signMessage(accountAddress: string, message: string | SignMessageObject): Promise<AccountTransactionSignature>;
 
     /**
      * Close the connection and clean up relevant resources.

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -7,7 +7,7 @@ import {
     SchemaVersion,
     UpdateContractPayload,
 } from '@concordium/web-sdk';
-import { SignMessageObject } from '@concordium/browser-wallet-api-helpers';
+import { SignMessageObject, SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
 
 // Copied from 'wallet-api-types.ts' in 'browser-wallet-api-helpers' as it isn't exported.
 type SendTransactionPayload =
@@ -70,7 +70,7 @@ export interface WalletConnection {
         accountAddress: string,
         type: AccountTransactionType.Update | AccountTransactionType.InitContract,
         payload: SendTransactionPayload,
-        parameters: Record<string, unknown>,
+        parameters: SmartContractParameters,
         schema: string,
         schemaVersion?: SchemaVersion
     ): Promise<string>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,6 +1526,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@concordium/browser-wallet-api-helpers@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@concordium/browser-wallet-api-helpers@npm:2.4.0"
+  dependencies:
+    "@concordium/web-sdk": ^3.4.0
+  checksum: 3c518068034e7e0ddd9b2932339bb198a64f77c1bc79989323514edb687be37a2505bb792b2b59775fee819bb7f995a8f57a183b9e09a129a04589cd511f7cc4
+  languageName: node
+  linkType: hard
+
 "@concordium/common-sdk@npm:6.2.0":
   version: 6.2.0
   resolution: "@concordium/common-sdk@npm:6.2.0"
@@ -1541,6 +1550,26 @@ __metadata:
     json-bigint: ^1.0.0
     uuid: ^8.3.2
   checksum: be2b3b10d05349dd0df1ab78e19addd9da8b2e0bfaa482beaaa54eafab8e656c9cc393cd2f52eaba7aa4c53d21b48332ef6fa4625acb411111cfb59a5c515832
+  languageName: node
+  linkType: hard
+
+"@concordium/common-sdk@npm:6.4.0":
+  version: 6.4.0
+  resolution: "@concordium/common-sdk@npm:6.4.0"
+  dependencies:
+    "@concordium/rust-bindings": 0.11.0
+    "@grpc/grpc-js": ^1.3.4
+    "@noble/ed25519": ^1.7.1
+    "@protobuf-ts/runtime-rpc": ^2.8.2
+    "@scure/bip39": ^1.1.0
+    bs58check: ^2.1.2
+    buffer: ^6.0.3
+    cross-fetch: 3.1.5
+    hash.js: ^1.1.7
+    iso-3166-1: ^2.1.1
+    json-bigint: ^1.0.0
+    uuid: ^8.3.2
+  checksum: d4d8fcd1961cfbe6939958afec90eeff05cc88c83cbb5bd6e1dcf5f887324e15b2c175e4e0dced4cf2860cdc06dcb945b94c88a7790f087028d4f1dcd9b40f86
   languageName: node
   linkType: hard
 
@@ -1570,6 +1599,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@concordium/rust-bindings@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@concordium/rust-bindings@npm:0.11.0"
+  checksum: a6c437cb782b7b2e9f217215dd4dbed9ffb8b3ef46fa307952aca3ae8f166cb96687de64efd18490aec7e86d58712dccb7d1a8bf63c151e3ed2a0170f066cd6d
+  languageName: node
+  linkType: hard
+
 "@concordium/rust-bindings@npm:0.9.0":
   version: 0.9.0
   resolution: "@concordium/rust-bindings@npm:0.9.0"
@@ -1581,7 +1617,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/wallet-connectors@workspace:packages/wallet-connectors"
   dependencies:
-    "@concordium/browser-wallet-api-helpers": ^2.0.0
+    "@concordium/browser-wallet-api-helpers": ^2.4.0
     "@tsconfig/recommended": ^1.0.1
     "@walletconnect/qrcode-modal": ^1.8.0
     "@walletconnect/sign-client": ^2.1.4
@@ -1611,6 +1647,20 @@ __metadata:
     buffer: ^6.0.3
     process: ^0.11.10
   checksum: e61bbfcca07e7d63035667324395d1f6bec2a7c17a0a2bab85d12b9ed3bf3203155ba9c0aa3df2fdf0c57e036d9fa1479ffa8399d7b08daf0edb4f14c9a5cb37
+  languageName: node
+  linkType: hard
+
+"@concordium/web-sdk@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@concordium/web-sdk@npm:3.4.0"
+  dependencies:
+    "@concordium/common-sdk": 6.4.0
+    "@concordium/rust-bindings": 0.11.0
+    "@grpc/grpc-js": ^1.3.4
+    "@protobuf-ts/grpcweb-transport": ^2.8.2
+    buffer: ^6.0.3
+    process: ^0.11.10
+  checksum: 65474ebc30bd846d5848a76732ee6517e644b63ea916b625625e2a9e42e4980eacbcdd21ce286d11e27d09b2a262847a5b42577a28c6950837ddfbc04625590d
   languageName: node
   linkType: hard
 
@@ -1809,6 +1859,31 @@ __metadata:
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
   checksum: 4059f790e2d07bf3c3ff3e0fec0daa8144fe35c1f6e0111c9921bd32106adaa97a4ab096ad7dab1e28ee6a9060083c4d1a4ada42a7f5f3f7a96b8812e2b757c1
+  languageName: node
+  linkType: hard
+
+"@grpc/grpc-js@npm:^1.3.4":
+  version: 1.8.13
+  resolution: "@grpc/grpc-js@npm:1.8.13"
+  dependencies:
+    "@grpc/proto-loader": ^0.7.0
+    "@types/node": ">=12.12.47"
+  checksum: bc74a6aa4c677ec7824c26f94b9270cab2489b2ebe9731d8acc2a15e882b6d2a9d20e1205938862fc20296e9784a33b0818427e426718ebdd123e621041fd26c
+  languageName: node
+  linkType: hard
+
+"@grpc/proto-loader@npm:^0.7.0":
+  version: 0.7.6
+  resolution: "@grpc/proto-loader@npm:0.7.6"
+  dependencies:
+    "@types/long": ^4.0.1
+    lodash.camelcase: ^4.3.0
+    long: ^4.0.0
+    protobufjs: ^7.0.0
+    yargs: ^16.2.0
+  bin:
+    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
+  checksum: cc42649cf65c74f627ac80b1f3ed275c4cf96dbc27728cc887e91e217c69a3bd6b94dfa7571725a94538d84735af53d35e9583cc77eb65f3c035106216cc4a1b
   languageName: node
   linkType: hard
 
@@ -2321,6 +2396,105 @@ __metadata:
   version: 2.11.6
   resolution: "@popperjs/core@npm:2.11.6"
   checksum: 47fb328cec1924559d759b48235c78574f2d71a8a6c4c03edb6de5d7074078371633b91e39bbf3f901b32aa8af9b9d8f82834856d2f5737a23475036b16817f0
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/grpcweb-transport@npm:^2.8.2":
+  version: 2.8.3
+  resolution: "@protobuf-ts/grpcweb-transport@npm:2.8.3"
+  dependencies:
+    "@protobuf-ts/runtime": ^2.8.3
+    "@protobuf-ts/runtime-rpc": ^2.8.3
+  checksum: 22b748e6e4f218bc86023bd9a180279ed7fbccc1169c93ab382a94b22868cbfc823eecb84e38213930206f2e78eb2913d4b7e2fabc479388496db7f00112c602
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/runtime-rpc@npm:^2.8.2, @protobuf-ts/runtime-rpc@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "@protobuf-ts/runtime-rpc@npm:2.8.3"
+  dependencies:
+    "@protobuf-ts/runtime": ^2.8.3
+  checksum: 9b6124abde33669ba87f15f921d6fcc60d09cfd2ffcbdda257e791edbd5be0c66f682ac207843f5841ba829354ec86664c627a4c2cdce3525f4cf9e3db8fdbdf
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/runtime@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "@protobuf-ts/runtime@npm:2.8.3"
+  checksum: b5237c5ec4b05f407a8afb51e066a5e27d03da55763e9c83a0d0d32433d95d0b8be0cdf5bcafb5616250c382299dc7c9f9b8a4334813e2cb4615e27a971daada
+  languageName: node
+  linkType: hard
+
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 011fe7ef0826b0fd1a95935a033a3c0fd08483903e1aa8f8b4e0704e3233406abb9ee25350ec0c20bbecb2aad8da0dcea58b392bbd77d6690736f02c143865d2
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 67173ac34de1e242c55da52c2f5bdc65505d82453893f9b51dc74af9fe4c065cf4a657a4538e91b0d4a1a1e0a0642215e31894c31650ff6e3831471061e1ee9e
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 59240c850b1d3d0b56d8f8098dd04787dcaec5c5bd8de186fa548de86b86076e1c50e80144b90335e705a044edf5bc8b0998548474c2a10a98c7e004a1547e4b
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 0369163a3d226851682f855f81413cbf166cd98f131edb94a0f67f79e75342d86e89df9d7a1df08ac28be2bc77e0a7f0200526bb6c2a407abbfee1f0262d5fd7
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.1
+    "@protobufjs/inquire": ^1.1.0
+  checksum: 3fce7e09eb3f1171dd55a192066450f65324fd5f7cc01a431df01bb00d0a895e6bfb5b0c5561ce157ee1d886349c90703d10a4e11a1a256418ff591b969b3477
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 5781e1241270b8bd1591d324ca9e3a3128d2f768077a446187a049e36505e91bc4156ed5ac3159c3ce3d2ba3743dbc757b051b2d723eea9cd367bfd54ab29b2f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: ca06f02eaf65ca36fb7498fc3492b7fc087bfcc85c702bac5b86fad34b692bdce4990e0ef444c1e2aea8c034227bd1f0484be02810d5d7e931c55445555646f4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 856eeb532b16a7aac071cacde5c5620df800db4c80cee6dbc56380524736205aae21e5ae47739114bf669ab5e8ba0e767a282ad894f3b5e124197cb9224445ee
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: d6a34fbbd24f729e2a10ee915b74e1d77d52214de626b921b2d77288bd8f2386808da2315080f2905761527cceffe7ec34c7647bd21a5ae41a25e8212ff79451
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: f9bf3163d13aaa3b6f5e6fbf37a116e094ea021c0e1f2a7ccd0e12a29e2ce08dafba4e8b36e13f8ed7397e1591610ce880ed1289af4d66cf4ace8a36a9557278
   languageName: node
   linkType: hard
 
@@ -3122,6 +3296,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/long@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@types/long@npm:4.0.2"
+  checksum: d16cde7240d834cf44ba1eaec49e78ae3180e724cd667052b194a372f350d024cba8dd3f37b0864931683dab09ca935d52f0c4c1687178af5ada9fc85b0635f4
+  languageName: node
+  linkType: hard
+
 "@types/mime@npm:*":
   version: 3.0.1
   resolution: "@types/mime@npm:3.0.1"
@@ -3133,6 +3314,13 @@ __metadata:
   version: 18.11.18
   resolution: "@types/node@npm:18.11.18"
   checksum: 03f17f9480f8d775c8a72da5ea7e9383db5f6d85aa5fefde90dd953a1449bd5e4ffde376f139da4f3744b4c83942166d2a7603969a6f8ea826edfb16e6e3b49d
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0":
+  version: 18.15.11
+  resolution: "@types/node@npm:18.15.11"
+  checksum: 977b4ad04708897ff0eb049ecf82246d210939c82461922d20f7d2dcfd81bbc661582ba3af28869210f7e8b1934529dcd46bff7d448551400f9d48b9d3bddec3
   languageName: node
   linkType: hard
 
@@ -9648,6 +9836,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.camelcase@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.camelcase@npm:4.3.0"
+  checksum: cb9227612f71b83e42de93eccf1232feeb25e705bdb19ba26c04f91e885bfd3dd5c517c4a97137658190581d3493ea3973072ca010aab7e301046d90740393d1
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -9706,6 +9901,20 @@ __metadata:
     slice-ansi: ^4.0.0
     wrap-ansi: ^6.2.0
   checksum: ae2f85bbabc1906034154fb7d4c4477c79b3e703d22d78adee8b3862fa913942772e7fa11713e3d96fb46de4e3cabefbf5d0a544344f03b58d3c4bff52aa9eb2
+  languageName: node
+  linkType: hard
+
+"long@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "long@npm:4.0.0"
+  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
+  languageName: node
+  linkType: hard
+
+"long@npm:^5.0.0":
+  version: 5.2.1
+  resolution: "long@npm:5.2.1"
+  checksum: 9264da12d1b7df67e5aa6da4498144293caf1ad12e7f092efe4e9a2d32c53f0bbf7334f7cef997080a2a3af061142558ab366efa71698d98b1cdb883477445a7
   languageName: node
   linkType: hard
 
@@ -11822,6 +12031,26 @@ __metadata:
     object-assign: ^4.1.1
     react-is: ^16.13.1
   checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.0.0":
+  version: 7.2.3
+  resolution: "protobufjs@npm:7.2.3"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: 9afa6de5fced0139a5180c063718508fac3ea734a9f1aceb99712367b15473a83327f91193f16b63540f9112b09a40912f5f0441a9b0d3f3c6a1c7f707d78249
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

The browser wallet can now sign bytes as well. Expanding the library to enable passing an object (with schema) to be signed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
