### PR TITLE
SendTransaction: add support for specific schemas

### DIFF
--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Added exported constant `CONCORDIUM_WALLET_CONNECT_PROJECT_ID` that dApps may use when connecting to a Concordium mobile wallet.
+-  `sendTransaction` for smart contract transactions can receive schemas as object, to support schemas that are for the specific parameter.
 
 ### Changed
 

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -1,4 +1,4 @@
-import { detectConcordiumProvider, WalletApi } from '@concordium/browser-wallet-api-helpers';
+import { detectConcordiumProvider, SchemaWithContext, WalletApi } from '@concordium/browser-wallet-api-helpers';
 import {
     AccountTransactionPayload,
     AccountTransactionSignature,
@@ -109,7 +109,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         type: AccountTransactionType,
         payload: AccountTransactionPayload,
         parameters?: Record<string, unknown>,
-        schema?: string,
+        schema?: SchemaWithContext | string,
         schemaVersion?: SchemaVersion
     ): Promise<string> {
         if (

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -1,3 +1,4 @@
+import { SchemaWithContext } from '@concordium/browser-wallet-api-helpers';
 import {
     AccountTransactionPayload,
     AccountTransactionSignature,
@@ -70,7 +71,7 @@ export interface WalletConnection {
         type: AccountTransactionType.Update | AccountTransactionType.InitContract,
         payload: SendTransactionPayload,
         parameters: Record<string, unknown>,
-        schema: string,
+        schema: SchemaWithContext | string,
         schemaVersion?: SchemaVersion
     ): Promise<string>;
 


### PR DESCRIPTION
## Purpose

Update schema type to include `SchemaWithContext` and handle receiving that.
(The latest versions of the wallets supports sending the schema as an object) 

## Changes

Expand type for schema on `sendTransaction` and handle the different types.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
