### PR TITLE
wallet-connectors: Add support for signing both string and binary messages

### DIFF
--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   `WalletConnection` (breaking): Support both module and parameter schemas in `signAndSendTransaction`.
+-   `WalletConnection` (breaking): Support both module and type/parameter schemas in `signAndSendTransaction`.
     To migrate existing usage, wrap the schema string in the new function `moduleSchemaFromBase64(...)`.
 -   `WalletConnection` (breaking): Support both string and binary messages in `signMessage`.
     To migrate existing usage, wrap the message string in the new function `stringMessage(...)`.

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `WalletConnection` (breaking): Support both module and parameter schemas in `signAndSendTransaction`.
     To migrate existing usage, wrap the schema string in the new function `moduleSchemaFromBase64(...)`.
+-   `WalletConnection` (breaking): Support both string and binary messages in `signMessage`.
+    To migrate existing usage, wrap the message string in the new function `stringMessage(...)`.
 
 ## [0.2.3] - 2023-04-03
 

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -1,6 +1,7 @@
 import { detectConcordiumProvider, WalletApi, SchemaType } from '@concordium/browser-wallet-api-helpers';
 import { AccountTransactionPayload, AccountTransactionSignature, AccountTransactionType } from '@concordium/web-sdk';
 import {
+    SignableMessage,
     WalletConnectionDelegate,
     WalletConnection,
     WalletConnector,
@@ -141,7 +142,17 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         return this.client.sendTransaction(accountAddress, type, payload);
     }
 
-    async signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature> {
-        return this.client.signMessage(accountAddress, message);
+    async signMessage(accountAddress: string, message: SignableMessage): Promise<AccountTransactionSignature> {
+        switch (message.type) {
+            case 'StringMessage':
+                return this.client.signMessage(accountAddress, message.value);
+            case 'BinaryMessage':
+                return this.client.signMessage(accountAddress, {
+                    schema: message.schema.value.toString('base64'),
+                    data: message.value.toString('hex'),
+                });
+            default:
+                throw new UnreachableCaseError('message', message);
+        }
     }
 }

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -127,7 +127,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
                         },
                         schema.version
                     );
-                case 'ParameterSchema':
+                case 'TypeSchema':
                     return this.client.sendTransaction(accountAddress, type, payload, parameters, {
                         type: SchemaType.Parameter,
                         value: schema.value.toString('base64'),

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -142,17 +142,17 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         return this.client.sendTransaction(accountAddress, type, payload);
     }
 
-    async signMessage(accountAddress: string, message: SignableMessage): Promise<AccountTransactionSignature> {
-        switch (message.type) {
+    async signMessage(accountAddress: string, msg: SignableMessage): Promise<AccountTransactionSignature> {
+        switch (msg.type) {
             case 'StringMessage':
-                return this.client.signMessage(accountAddress, message.value);
+                return this.client.signMessage(accountAddress, msg.value);
             case 'BinaryMessage':
                 return this.client.signMessage(accountAddress, {
-                    schema: message.schema.value.toString('base64'),
-                    data: message.value.toString('hex'),
+                    schema: msg.schema.value.toString('base64'),
+                    data: msg.value.toString('hex'),
                 });
             default:
-                throw new UnreachableCaseError('message', message);
+                throw new UnreachableCaseError('message', msg);
         }
     }
 }

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -87,7 +87,7 @@ function serializeInitContractParam(initName: string, typedParams: TypedSmartCon
     switch (schema.type) {
         case 'ModuleSchema':
             return serializeInitContractParameters(initName, parameters, schema.value, schema.version);
-        case 'ParameterSchema':
+        case 'TypeSchema':
             return serializeTypeValue(parameters, schema.value);
         default:
             throw new UnreachableCaseError('schema', schema);
@@ -112,7 +112,7 @@ function serializeUpdateContractMessage(
                 schema.value,
                 schema.version
             );
-        case 'ParameterSchema':
+        case 'TypeSchema':
             return serializeTypeValue(parameters, schema.value);
         default:
             throw new UnreachableCaseError('schema', schema);

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -244,10 +244,10 @@ export class WalletConnectConnection implements WalletConnection {
         }
     }
 
-    async signMessage(accountAddress: string, message: SignableMessage) {
-        switch (message.type) {
+    async signMessage(accountAddress: string, msg: SignableMessage) {
+        switch (msg.type) {
             case 'StringMessage': {
-                const params = { message };
+                const params = { message: msg };
                 const signature = await this.connector.client.request({
                     topic: this.session.topic,
                     request: {
@@ -261,7 +261,7 @@ export class WalletConnectConnection implements WalletConnection {
             case 'BinaryMessage':
                 throw new Error(`signing 'BinaryMessage' is not yet supported by the mobile wallets`);
             default:
-                throw new UnreachableCaseError('message', message);
+                throw new UnreachableCaseError('message', msg);
         }
     }
 

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -247,7 +247,7 @@ export class WalletConnectConnection implements WalletConnection {
     async signMessage(accountAddress: string, msg: SignableMessage) {
         switch (msg.type) {
             case 'StringMessage': {
-                const params = { message: msg };
+                const params = { message: msg.value };
                 const signature = await this.connector.client.request({
                     topic: this.session.topic,
                     request: {

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -81,6 +81,43 @@ export type TypedSmartContractParameters = {
     schema: Schema;
 };
 
+export type StringMessage = {
+    type: 'StringMessage';
+    value: string;
+};
+
+export type BinaryMessage = {
+    type: 'BinaryMessage';
+    value: Buffer;
+    schema: ParameterSchema;
+};
+
+export type SignableMessage = StringMessage | BinaryMessage;
+
+export function stringMessage(msg: string): StringMessage {
+    return {
+        type: 'StringMessage',
+        value: msg,
+    };
+}
+
+export function binaryMessageFromHex(msgHex: string, schema: ParameterSchema): BinaryMessage {
+    return {
+        type: 'BinaryMessage',
+        value: messageAsBuffer(msgHex),
+        schema,
+    };
+}
+
+function messageAsBuffer(msgHex: string) {
+    const res = toBuffer(msgHex, 'hex');
+    // Check round-trip.
+    if (res.toString('hex') !== msgHex) {
+        throw new Error(`provided message '${msgHex}' is not valid hex`);
+    }
+    return res;
+}
+
 /**
  * Interface for interacting with a wallet backend through a connection that's already been established.
  * The connected account (and in turn connected network/chain) is managed by the wallet
@@ -150,7 +187,7 @@ export interface WalletConnection {
      * @param message The message to sign.
      * @return A promise for the signatures of the message.
      */
-    signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature>;
+    signMessage(accountAddress: string, message: SignableMessage): Promise<AccountTransactionSignature>;
 
     /**
      * Close the connection and clean up relevant resources.

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -13,8 +13,8 @@ export type ModuleSchema = {
     value: Buffer;
     version?: SchemaVersion;
 };
-export type ParameterSchema = {
-    type: 'ParameterSchema';
+export type TypeSchema = {
+    type: 'TypeSchema';
     value: Buffer;
 };
 
@@ -22,7 +22,7 @@ export type ParameterSchema = {
  * Discriminated union type for contract invocation schemas.
  * Is used to select the correct method for encoding the invocation parameters using the schema.
  */
-export type Schema = ModuleSchema | ParameterSchema;
+export type Schema = ModuleSchema | TypeSchema;
 
 /**
  * {@link Schema} constructor for a module schema.
@@ -48,21 +48,21 @@ export function moduleSchema(schema: Buffer, version?: SchemaVersion): ModuleSch
 }
 
 /**
- * {@link Schema} constructor for a parameter schema.
+ * {@link Schema} constructor for a type schema.
  * @param schemaBase64 The raw parameter schema in base64 encoding.
  * @throws Error if {@link schemaBase64} is not valid base64.
  */
-export function parameterSchemaFromBase64(schemaBase64: string): ParameterSchema {
-    return parameterSchema(schemaAsBuffer(schemaBase64));
+export function typeSchemaFromBase64(schemaBase64: string): TypeSchema {
+    return typeSchema(schemaAsBuffer(schemaBase64));
 }
 
 /**
- * {@link Schema} constructor for a parameter schema.
+ * {@link Schema} constructor for a type schema.
  * @param schema The raw parameter schema in binary.
  */
-export function parameterSchema(schema: Buffer): ParameterSchema {
+export function typeSchema(schema: Buffer): TypeSchema {
     return {
-        type: 'ParameterSchema',
+        type: 'TypeSchema',
         value: schema,
     };
 }
@@ -88,7 +88,7 @@ export type StringMessage = {
 export type BinaryMessage = {
     type: 'BinaryMessage';
     value: Buffer;
-    schema: ParameterSchema;
+    schema: TypeSchema;
 };
 
 /**
@@ -112,7 +112,7 @@ export function stringMessage(msg: string): StringMessage {
  * @param msgHex The message represented in hexadecimal notation.
  * @param schema The schema describing the type of the binary message.
  */
-export function binaryMessageFromHex(msgHex: string, schema: ParameterSchema): BinaryMessage {
+export function binaryMessageFromHex(msgHex: string, schema: TypeSchema): BinaryMessage {
     return {
         type: 'BinaryMessage',
         value: messageAsBuffer(msgHex),

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -85,15 +85,21 @@ export type StringMessage = {
     type: 'StringMessage';
     value: string;
 };
-
 export type BinaryMessage = {
     type: 'BinaryMessage';
     value: Buffer;
     schema: ParameterSchema;
 };
 
+/**
+ * Discriminated union type for signable messages.
+ */
 export type SignableMessage = StringMessage | BinaryMessage;
 
+/**
+ * {@link SignableMessage} constructor for a string message.
+ * @param msg The message as a plain string.
+ */
 export function stringMessage(msg: string): StringMessage {
     return {
         type: 'StringMessage',
@@ -101,6 +107,11 @@ export function stringMessage(msg: string): StringMessage {
     };
 }
 
+/**
+ * {@link SignableMessage} constructor for binary message.
+ * @param msgHex The message represented in hexadecimal notation.
+ * @param schema The schema describing the type of the binary message.
+ */
 export function binaryMessageFromHex(msgHex: string, schema: ParameterSchema): BinaryMessage {
     return {
         type: 'BinaryMessage',
@@ -184,10 +195,10 @@ export interface WalletConnection {
      * If this doesn't happen, the promise rejects with an explanatory error message.
      *
      * @param accountAddress The account whose keys are used to sign the message.
-     * @param message The message to sign.
+     * @param msg The message to sign.
      * @return A promise for the signatures of the message.
      */
-    signMessage(accountAddress: string, message: SignableMessage): Promise<AccountTransactionSignature>;
+    signMessage(accountAddress: string, msg: SignableMessage): Promise<AccountTransactionSignature>;
 
     /**
      * Close the connection and clean up relevant resources.

--- a/samples/contractupdate/src/ContractInvoker.tsx
+++ b/samples/contractupdate/src/ContractInvoker.tsx
@@ -2,7 +2,7 @@ import {
     Info,
     moduleSchemaFromBase64,
     Network,
-    parameterSchemaFromBase64,
+    typeSchemaFromBase64,
     Schema,
     WalletConnection,
 } from '@concordium/react-components';
@@ -26,7 +26,7 @@ interface ContractInvokerProps {
 }
 
 enum SchemaType {
-    Parameter = 'Parameter',
+    Type = 'Type',
     Module = 'Module (auto)',
     ModuleV2 = 'Module (v2)',
     ModuleV1 = 'Module (v1)',
@@ -51,8 +51,8 @@ function schemaTypeFromSchema(schemaFromRpc: Schema | undefined, inputSchemaType
                 default:
                     throw new Error(`unexpected schema version "${schemaFromRpc.version}"`);
             }
-        case 'ParameterSchema':
-            return SchemaType.Parameter;
+        case 'TypeSchema':
+            return SchemaType.Type;
     }
 }
 
@@ -68,8 +68,8 @@ function schemaOfType(type: SchemaType, schemaBase64: string): Schema {
             return moduleSchemaFromBase64(schemaBase64, SchemaVersion.V1);
         case SchemaType.ModuleV2:
             return moduleSchemaFromBase64(schemaBase64, SchemaVersion.V2);
-        case SchemaType.Parameter:
-            return parameterSchemaFromBase64(schemaBase64);
+        case SchemaType.Type:
+            return typeSchemaFromBase64(schemaBase64);
         default:
             throw new Error(`unsupported schema type "${type}"`);
     }
@@ -224,8 +224,8 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
                                     () => false
                                 )}
                             >
-                                <Dropdown.Item onClick={() => setSchemaTypeInput(SchemaType.Parameter)}>
-                                    Parameter schema
+                                <Dropdown.Item onClick={() => setSchemaTypeInput(SchemaType.Type)}>
+                                    Type schema
                                 </Dropdown.Item>
                                 <Dropdown.Item onClick={() => setSchemaTypeInput(SchemaType.Module)}>
                                     Module schema (auto)

--- a/samples/contractupdate/src/ContractInvoker.tsx
+++ b/samples/contractupdate/src/ContractInvoker.tsx
@@ -100,7 +100,7 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
 
     const schemaRpcResult = useContractSchemaRpc(connection, contract);
 
-    const [schemaTypeInput, setSchemaTypeInput] = useState<SchemaType>(DEFAULT_SCHEMA_TYPE);
+    const [schemaTypeInput, setSchemaTypeInput] = useState(DEFAULT_SCHEMA_TYPE);
 
     const [contractParams, setContractParams] = useState<Array<ContractParamEntry>>([]);
     const [contractAmountInput, setContractAmountInput] = useState('');
@@ -197,7 +197,7 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
                         Schema (base64):
                     </Form.Label>
                     <Col sm={10}>
-                        <InputGroup hasValidation={true}>
+                        <InputGroup hasValidation>
                             <Form.Control
                                 value={schemaInput}
                                 onChange={onSchemaChange}

--- a/samples/sign-message/src/App.tsx
+++ b/samples/sign-message/src/App.tsx
@@ -8,7 +8,7 @@ import {
     WithWalletConnector,
     binaryMessageFromHex,
     stringMessage,
-    parameterSchemaFromBase64,
+    typeSchemaFromBase64,
 } from '@concordium/react-components';
 import { Alert, Button, Col, Container, Form, InputGroup, Row, Spinner } from 'react-bootstrap';
 import { WalletConnectorButton } from './WalletConnectorButton';
@@ -38,7 +38,7 @@ function Main(props: WalletConnectionProps) {
             return undefined;
         }
         try {
-            return ok(parameterSchemaFromBase64(schemaInput));
+            return ok(typeSchemaFromBase64(schemaInput));
         } catch (e) {
             return err(errorString(e));
         }

--- a/samples/sign-message/src/App.tsx
+++ b/samples/sign-message/src/App.tsx
@@ -55,7 +55,10 @@ function Main(props: WalletConnectionProps) {
         try {
             // Map schema result to message with input.
             // Return undefined if schema result is an error to avoid double reporting it.
-            return schemaResult.match(s => ok(binaryMessageFromHex(messageInput, s)), () => undefined);
+            return schemaResult.match(
+                (s) => ok(binaryMessageFromHex(messageInput, s)),
+                () => undefined
+            );
         } catch (e) {
             return err(errorString(e));
         }
@@ -135,9 +138,12 @@ function Main(props: WalletConnectionProps) {
                             autoFocus
                         />
                         <InputGroup.Text>Base64</InputGroup.Text>
-                        {schemaResult?.match(() => undefined, (e) => (
-                            <Form.Control.Feedback type="invalid">{e}</Form.Control.Feedback>
-                        ))}
+                        {schemaResult?.match(
+                            () => undefined,
+                            (e) => (
+                                <Form.Control.Feedback type="invalid">{e}</Form.Control.Feedback>
+                            )
+                        )}
                     </InputGroup>
                 </Col>
             </Form.Group>
@@ -147,25 +153,32 @@ function Main(props: WalletConnectionProps) {
                 </Form.Label>
                 <Col sm={9}>
                     <InputGroup hasValidation={messageResult?.isErr()}>
-                        <Form.Control type="text" value={messageInput} onChange={handleMessageInput} isInvalid={messageResult?.isErr()} autoFocus />
+                        <Form.Control
+                            type="text"
+                            value={messageInput}
+                            onChange={handleMessageInput}
+                            isInvalid={messageResult?.isErr()}
+                            autoFocus
+                        />
                         <InputGroup.Text>{schemaInput ? 'Hex' : 'String'}</InputGroup.Text>
-                        {messageResult?.match(() => undefined, (e) => (
-                            <Form.Control.Feedback type="invalid">{e}</Form.Control.Feedback>
-                        ))}
+                        {messageResult?.match(
+                            () => undefined,
+                            (e) => (
+                                <Form.Control.Feedback type="invalid">{e}</Form.Control.Feedback>
+                            )
+                        )}
                     </InputGroup>
                 </Col>
             </Form.Group>
             <Form.Group as={Row} className="mb-3">
-                <Form.Label column sm={3}/>
+                <Form.Label column sm={3} />
                 <Col sm={9}>
                     <Button
                         variant="primary"
                         onClick={handleSubmit}
                         disabled={!connection || !messageInput || isWaiting || !messageResult?.isOk()}
                     >
-                        {isWaiting
-                            ? 'Signing...'
-                            : schemaInput ? 'Sign binary message' : 'Sign string message'}
+                        {isWaiting ? 'Signing...' : schemaInput ? 'Sign binary message' : 'Sign string message'}
                     </Button>
                 </Col>
             </Form.Group>

--- a/samples/sign-message/src/App.tsx
+++ b/samples/sign-message/src/App.tsx
@@ -1,10 +1,20 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { ResultAsync, ok, err } from 'neverthrow';
 import { TESTNET } from './config';
-import { useConnect, useConnection, WalletConnectionProps, WithWalletConnector } from '@concordium/react-components';
+import {
+    useConnect,
+    useConnection,
+    WalletConnectionProps,
+    WithWalletConnector,
+    binaryMessageFromHex,
+    stringMessage,
+    parameterSchemaFromBase64,
+} from '@concordium/react-components';
 import { Alert, Button, Col, Container, Form, InputGroup, Row, Spinner } from 'react-bootstrap';
 import { WalletConnectorButton } from './WalletConnectorButton';
 import { BROWSER_WALLET, WALLET_CONNECT } from './config';
 import { AccountTransactionSignature } from '@concordium/web-sdk';
+import { errorString } from './util';
 
 export default function App() {
     return (
@@ -20,23 +30,55 @@ function Main(props: WalletConnectionProps) {
     const { connection, setConnection, account } = useConnection(connectedAccounts, genesisHashes);
     const { connect, isConnecting, connectError } = useConnect(activeConnector, setConnection);
 
-    const [message, setMessage] = useState('');
+    const [messageInput, setMessageInput] = useState('');
+    const [schemaInput, setSchemaInput] = useState('');
+
+    const schemaResult = useMemo(() => {
+        if (!schemaInput) {
+            return undefined;
+        }
+        try {
+            return ok(parameterSchemaFromBase64(schemaInput));
+        } catch (e) {
+            return err(errorString(e));
+        }
+    }, [schemaInput]);
+
+    const messageResult = useMemo(() => {
+        if (!messageInput) {
+            return undefined;
+        }
+        if (!schemaResult) {
+            // Empty schema implies string message.
+            return ok(stringMessage(messageInput));
+        }
+        try {
+            // Map schema result to message with input.
+            // Return undefined if schema result is an error to avoid double reporting it.
+            return schemaResult.match(s => ok(binaryMessageFromHex(messageInput, s)), () => undefined);
+        } catch (e) {
+            return err(errorString(e));
+        }
+    }, [messageInput, schemaResult]);
+
     const [signature, setSignature] = useState<AccountTransactionSignature>('');
     const [error, setError] = useState('');
     const [isWaiting, setIsWaiting] = useState(false);
 
-    const handleInput = useCallback((e: any) => setMessage(e.target.value), []);
+    const handleMessageInput = useCallback((e: any) => setMessageInput(e.target.value), []);
+    const handleSchemaInput = useCallback((e: any) => setSchemaInput(e.target.value), []);
     const handleSubmit = useCallback(() => {
-        if (connection && account && message) {
-            setError('');
-            setIsWaiting(true);
-            connection
-                .signMessage(account, message)
-                .then((m) => setSignature(m))
-                .catch((e) => setError((e as Error).message || e))
+        if (connection && account && messageResult) {
+            messageResult
+                .asyncAndThen((msg) => {
+                    setError('');
+                    setIsWaiting(true);
+                    return ResultAsync.fromPromise(connection.signMessage(account, msg), errorString);
+                })
+                .match(setSignature, setError)
                 .finally(() => setIsWaiting(false));
         }
-    }, [connection, account, message]);
+    }, [connection, account, messageResult]);
     return (
         <>
             <Row className="mt-3 mb-3">
@@ -78,28 +120,53 @@ function Main(props: WalletConnectionProps) {
                     </Col>
                 </Row>
             )}
-            <Form.Group as={Row} className="mb-3" controlId="contract">
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={3}>
+                    Schema (if binary):
+                </Form.Label>
+                <Col sm={9}>
+                    <InputGroup hasValidation={schemaResult?.isErr()}>
+                        <Form.Control
+                            type="text"
+                            value={schemaInput}
+                            onChange={handleSchemaInput}
+                            placeholder="Leave empty for string message"
+                            isInvalid={schemaResult?.isErr()}
+                            autoFocus
+                        />
+                        <InputGroup.Text>Base64</InputGroup.Text>
+                        {schemaResult?.match(() => undefined, (e) => (
+                            <Form.Control.Feedback type="invalid">{e}</Form.Control.Feedback>
+                        ))}
+                    </InputGroup>
+                </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-3">
                 <Form.Label column sm={3}>
                     Message to sign:
                 </Form.Label>
                 <Col sm={9}>
-                    <InputGroup>
-                        <Form.Control
-                            type="text"
-                            value={message}
-                            onChange={handleInput}
-                            disabled={!connection}
-                            placeholder={connection ? undefined : 'Connect wallet to sign message'}
-                            autoFocus
-                        />
-                        <Button
-                            variant="primary"
-                            onClick={handleSubmit}
-                            disabled={!connection || !message || isWaiting}
-                        >
-                            {isWaiting ? 'Signing...' : 'Sign'}
-                        </Button>
+                    <InputGroup hasValidation={messageResult?.isErr()}>
+                        <Form.Control type="text" value={messageInput} onChange={handleMessageInput} isInvalid={messageResult?.isErr()} autoFocus />
+                        <InputGroup.Text>{schemaInput ? 'Hex' : 'String'}</InputGroup.Text>
+                        {messageResult?.match(() => undefined, (e) => (
+                            <Form.Control.Feedback type="invalid">{e}</Form.Control.Feedback>
+                        ))}
                     </InputGroup>
+                </Col>
+            </Form.Group>
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={3}/>
+                <Col sm={9}>
+                    <Button
+                        variant="primary"
+                        onClick={handleSubmit}
+                        disabled={!connection || !messageInput || isWaiting || !messageResult?.isOk()}
+                    >
+                        {isWaiting
+                            ? 'Signing...'
+                            : schemaInput ? 'Sign binary message' : 'Sign string message'}
+                    </Button>
                 </Col>
             </Form.Group>
             <Row>
@@ -108,7 +175,7 @@ function Main(props: WalletConnectionProps) {
                     <>
                         <Col sm={3}>Signature:</Col>
                         <Col sm={9}>
-                            <pre title={`Message: ${message}`}>{JSON.stringify(signature, null, 2)}</pre>
+                            <pre title={`Message: ${messageInput}`}>{JSON.stringify(signature, null, 2)}</pre>
                         </Col>
                     </>
                 )}

--- a/samples/sign-message/src/App.tsx
+++ b/samples/sign-message/src/App.tsx
@@ -183,7 +183,7 @@ function Main(props: WalletConnectionProps) {
                 </Col>
             </Form.Group>
             <Row>
-                {error && <Alert variant="danger"></Alert>}
+                {error && <Alert variant="danger">{error}</Alert>}
                 {signature && (
                     <>
                         <Col sm={3}>Signature:</Col>

--- a/samples/sign-message/src/util.ts
+++ b/samples/sign-message/src/util.ts
@@ -1,0 +1,7 @@
+export function setErrorString(setError: (err: string) => void) {
+    return (err: any) => setError(errorString(err));
+}
+
+export function errorString(err: any): string {
+    return (err as Error).message || (err as string);
+}


### PR DESCRIPTION
## Purpose

Add support for signing both string and binary messages in the `WalletConnection` interface. Fully implemented for Browser Wallet, partially for WalletConnect.

## Changes

Replaced the `string` message type in `signMessage` with a new type `SignableMessage` which is a discriminated union of a binary message (which has a *type/parameter* schema) and a simple string message.

The mobile wallets don't yet support signing binary messages, so the WalletConnect implementation throws an exception for that case. It's very non-desirable to throw exceptions at use time for unimplemented features as compared to enabling the dApp to detect available features for a given connection. But in this case, the warts that this would impose on the interface are not deemed worth it: The MW aren't lacking the feature, it's more like they aren't entirely done implementing it...

The sample dApp `sign-message` is updated to support both variants by adding a "schema" input for the parameter schema (represented as base64). If this input is non-empty, the message is assumed to be binary (represented as hex). Otherwise it's a plain string.

Also, renamed `ParameterSchema` to `TypeSchema` to make it more semantically correct to use this in the context of message values.

This PR is an alternative to #32.