### PR TITLE
Deprecate JSON-RPC support and add support for using the gRPC client for Node API v2

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Hook `useGrpcClient` for obtaining a gRPC Web client `ConcordiumGRPCClient` that connects to the appropriate network.
+
 ## [0.2.1] - 2023-03-17
 
 ### Changed

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -122,16 +122,15 @@ _Example: Look up the info of a smart contract by its index specified in an inpu
 ```typescript jsx
 import React, { useState } from 'react';
 import { Network, useContractSelector, WalletConnection } from '@concordium/react-components';
+import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 
 interface Props {
-    network: Network;
-    connection: WalletConnection | undefined;
-    connectedAccount: string | undefined;
+    rpc: ConcordiumGRPCClient | undefined;
 }
 
-export function ContractStuff({ connection }: Props) {
+export function ContractStuff({ rpc }: Props) {
     const [input, setInput] = useState('');
-    const { selected, isLoading, validationError } = useContractSelector(connection?.getJsonRpcClient(), input);
+    const { selected, isLoading, validationError } = useContractSelector(rpc, input);
     return (
         // TODO Render a text input using `input`/`setInput`.
         // TODO Render the selected contract, if present.
@@ -139,7 +138,32 @@ export function ContractStuff({ connection }: Props) {
 }
 ```
 
+Use the hook [`useGrpcClient`](#usegrpcclient) below to obtain a `ConcordiumGRPCClient` instance.
 See [the sample dApp](../../samples/contractupdate/src/App.tsx) for a complete example.
+
+### [`useGrpcClient`](./src/useGrpcClient.ts)
+
+React hook that obtains a gRPC Web client for interacting with a node on the appropriate network.
+
+_Example: Periodically fetch height of "best block"_
+
+```typescript
+const rpc = useGrpcClient(network);
+const [height, setHeight] = useState<bigint>();
+useEffect(() => {
+    const t = setInterval(() => {
+        if (rpc) {
+            rpc.getConsensusStatus()
+                .then((s) => s.bestBlockHeight)
+                .then(setHeight)
+                .catch(console.error);
+        }
+    }, intervalMs);
+    return () => clearTimeout(t);
+}, [rpc]);
+```
+
+The client is also used as an input to the hook [`useContractSelector`](#usecontractselector) above.
 
 ## Build
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -20,7 +20,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/wallet-connectors": "^0.2.1"
+        "@concordium/wallet-connectors": "^0.2.3"
     },
     "devDependencies": {
         "@tsconfig/recommended": "^1.0.1",

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -1,6 +1,7 @@
 export * from './useConnect';
 export * from './useConnection';
 export * from './useContractSelector';
+export * from './useGrpcClient';
 export * from './useWalletConnectorSelector';
 export * from './WithWalletConnector';
 export * from '@concordium/wallet-connectors';

--- a/packages/react-components/src/useContractSelector.ts
+++ b/packages/react-components/src/useContractSelector.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { AccountAddress, CcdAmount, JsonRpcClient } from '@concordium/web-sdk';
+import { AccountAddress, CcdAmount, ConcordiumGRPCClient, JsonRpcClient } from '@concordium/web-sdk';
 import { errorString } from './error';
 
 /**
@@ -42,7 +42,7 @@ export interface Info {
     moduleRef: string;
 }
 
-async function refresh(rpc: JsonRpcClient, index: bigint) {
+async function refresh(rpc: ConcordiumGRPCClient | JsonRpcClient , index: bigint) {
     const info = await rpc.getInstanceInfo({ index, subindex: BigInt(0) });
     if (!info) {
         throw new Error(`contract ${index} not found`);
@@ -72,7 +72,7 @@ function parseContractIndex(input: string) {
     }
 }
 
-async function loadContract(rpc: JsonRpcClient, input: string) {
+async function loadContract(rpc: ConcordiumGRPCClient | JsonRpcClient, input: string) {
     const index = parseContractIndex(input);
     return refresh(rpc, index);
 }
@@ -105,7 +105,7 @@ export interface ContractSelector {
  * @param input The index of the contract to look up.
  * @return The resolved contract and related state.
  */
-export function useContractSelector(rpc: JsonRpcClient | undefined, input: string): ContractSelector {
+export function useContractSelector(rpc: ConcordiumGRPCClient | JsonRpcClient | undefined, input: string): ContractSelector {
     const [selected, setSelected] = useState<Info>();
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');

--- a/packages/react-components/src/useContractSelector.ts
+++ b/packages/react-components/src/useContractSelector.ts
@@ -42,7 +42,7 @@ export interface Info {
     moduleRef: string;
 }
 
-async function refresh(rpc: ConcordiumGRPCClient | JsonRpcClient , index: bigint) {
+async function refresh(rpc: ConcordiumGRPCClient | JsonRpcClient, index: bigint) {
     const info = await rpc.getInstanceInfo({ index, subindex: BigInt(0) });
     if (!info) {
         throw new Error(`contract ${index} not found`);
@@ -105,7 +105,10 @@ export interface ContractSelector {
  * @param input The index of the contract to look up.
  * @return The resolved contract and related state.
  */
-export function useContractSelector(rpc: ConcordiumGRPCClient | JsonRpcClient | undefined, input: string): ContractSelector {
+export function useContractSelector(
+    rpc: ConcordiumGRPCClient | JsonRpcClient | undefined,
+    input: string
+): ContractSelector {
     const [selected, setSelected] = useState<Info>();
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');

--- a/packages/react-components/src/useGrpcClient.ts
+++ b/packages/react-components/src/useGrpcClient.ts
@@ -3,18 +3,14 @@ import { Network } from '@concordium/wallet-connectors';
 import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 
-export interface GrpcClient {
-    grpcClient: ConcordiumGRPCClient | undefined;
-}
-
-export function useGrpcClient({ grpcOpts }: Network): GrpcClient {
-    const [grpcClient, setGrpcClient] = useState<ConcordiumGRPCClient>();
+export function useGrpcClient({ grpcOpts }: Network): ConcordiumGRPCClient | undefined {
+    const [client, setClient] = useState<ConcordiumGRPCClient>();
     useEffect(() => {
         if (!grpcOpts) {
-            return setGrpcClient(undefined);
+            return setClient(undefined);
         }
-        // No exceptions should be thrown from here.
-        setGrpcClient(new ConcordiumGRPCClient(new GrpcWebFetchTransport(grpcOpts)));
+        // No exceptions should ever be thrown from here.
+        setClient(new ConcordiumGRPCClient(new GrpcWebFetchTransport(grpcOpts)));
     }, [grpcOpts]);
-    return { grpcClient };
+    return client;
 }

--- a/packages/react-components/src/useGrpcClient.ts
+++ b/packages/react-components/src/useGrpcClient.ts
@@ -3,6 +3,9 @@ import { Network } from '@concordium/wallet-connectors';
 import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 
+/**
+ * React hook that obtains a gRPC Web client for interacting with a node on the appropriate network.
+ */
 export function useGrpcClient({ grpcOpts }: Network): ConcordiumGRPCClient | undefined {
     const [client, setClient] = useState<ConcordiumGRPCClient>();
     useEffect(() => {

--- a/packages/react-components/src/useGrpcClient.ts
+++ b/packages/react-components/src/useGrpcClient.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { Network } from '@concordium/wallet-connectors';
+import { ConcordiumGRPCClient } from '@concordium/web-sdk';
+import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
+
+export interface GrpcClient {
+    grpcClient: ConcordiumGRPCClient | undefined;
+}
+
+export function useGrpcClient({ grpcOpts }: Network): GrpcClient {
+    const [grpcClient, setGrpcClient] = useState<ConcordiumGRPCClient>();
+    useEffect(() => {
+        if (!grpcOpts) {
+            return setGrpcClient(undefined);
+        }
+        setGrpcClient(new ConcordiumGRPCClient(new GrpcWebFetchTransport(grpcOpts)));
+    }, [grpcOpts]);
+    return { grpcClient };
+}

--- a/packages/react-components/src/useGrpcClient.ts
+++ b/packages/react-components/src/useGrpcClient.ts
@@ -13,6 +13,7 @@ export function useGrpcClient({ grpcOpts }: Network): GrpcClient {
         if (!grpcOpts) {
             return setGrpcClient(undefined);
         }
+        // No exceptions should be thrown from here.
         setGrpcClient(new ConcordiumGRPCClient(new GrpcWebFetchTransport(grpcOpts)));
     }, [grpcOpts]);
     return { grpcClient };

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `WalletConnection`: Add method `getGrpcClient` for obtaining a preconfigured gRPC Web client for querying a Node via API version 2.
+    This deprecates the existing method `getJsonRpcClient` in favor of the new one.
+
 ### Changed
 
 -   `WalletConnection` (breaking): Support both module and type/parameter schemas in `signAndSendTransaction`.

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   `WalletConnection`: Add method `getGrpcClient` for obtaining a preconfigured gRPC Web client for querying a Node via API version 2.
-    This deprecates the existing method `getJsonRpcClient` in favor of the new one.
+-   Standard values of `Network` for testnet and mainnet, exposed as constants `TESTNET` and `MAINNET`.
 
 ### Changed
 
@@ -18,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     To migrate existing usage, wrap the schema string in the new function `moduleSchemaFromBase64(...)`.
 -   `WalletConnection` (breaking): Support both string and binary messages in `signMessage`.
     To migrate existing usage, wrap the message string in the new function `stringMessage(...)`.
+-   `WalletConnection`: Deprecate the method `getJsonRpcClient` on `WalletConnection`
+    in favor of the gRPC Web client `ConcordiumGRPCClient` for querying a Node via API version 2.
+    The client should be managed independently of this library, e.g. using `useGrpcClient` in `@concordium/react-components`.
 
 ## [0.2.3] - 2023-04-03
 

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `WalletConnection`: Deprecate the method `getJsonRpcClient` on `WalletConnection`
     in favor of the gRPC Web client `ConcordiumGRPCClient` for querying a Node via API version 2.
     The client should be managed independently of this library, e.g. using `useGrpcClient` in `@concordium/react-components`.
--   `Network`: Add field `grpcOpts` containing the initialization options for a gRPC Web client `ConcordiumGRPCClient` to connect to the given network.
+-   `Network`: Add field `grpcOpts` containing the initialization options for a gRPC Web client `ConcordiumGRPCClient`
+    to connect to the given network.
+    If field `jsonRpcUrl` is empty, the JSON-RPC client is not initialized for WalletConnect connections,
+    and if so, `getJsonRpcClient` will throw an exception.
 
 ## [0.2.3] - 2023-04-03
 

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `WalletConnection`: Deprecate the method `getJsonRpcClient` on `WalletConnection`
     in favor of the gRPC Web client `ConcordiumGRPCClient` for querying a Node via API version 2.
     The client should be managed independently of this library, e.g. using `useGrpcClient` in `@concordium/react-components`.
+-   `Network`: Add field `grpcOpts` containing the initialization options for a gRPC Web client `ConcordiumGRPCClient` to connect to the given network.
 
 ## [0.2.3] - 2023-04-03
 

--- a/packages/wallet-connectors/README.md
+++ b/packages/wallet-connectors/README.md
@@ -23,12 +23,12 @@ Implementations may support multiple active connections from the same connector.
 ### `WalletConnection`
 
 A connection allows the application to interact with a wallet.
-The following kinds of interactions are supported:
+The following interactions are supported:
 
--   Ask the wallet to sign a message
--   Ask the wallet to sign and send a transaction.
+-   `signMessage`: Ask the wallet to sign a message and return it back to the dApp.
+-   `signAndSendTransaction`: Ask the wallet to sign a transaction and submit it to a node.
 
-The wallet is responsible for prompting for approval of all interactions.
+The wallet is responsible for prompting its user for approval of all interactions.
 
 ### `WalletConnectionDelegate`
 

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -20,7 +20,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/browser-wallet-api-helpers": "^2.4.0",
+        "@concordium/browser-wallet-api-helpers": "^2.5.0",
         "@walletconnect/qrcode-modal": "^1.8.0",
         "@walletconnect/sign-client": "^2.1.4"
     },

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -93,18 +93,19 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
     /**
      * Returns a gRPC client that is ready to perform requests against some Concordium Node connected to network/chain
      * that the connected account lives on.
-     * The client implements version 2 of the Node's API.
+     * The client implements version 2 of the Node API.
      *
-     * This method is included because it's part of the Browser Wallet's API.
+     * This method is included because it's part of the Browser Wallet API.
      * It should be used with care as it's hard to guarantee that it actually connects to the expected network.
      * The recommended alternative is to have the application instantiate its own instance
      * that is independent of any connection.
      * See {@link Network.grpcOpts} for more details.
      *
-     * Note that this method cannot be moved to {@link WalletConnector} as the Browser Wallet's RPC client doesn't work
-     * until a connection has been established.
+     * Implementation detail: The method cannot be moved to {@link WalletConnector}
+     * as the Browser Wallet's RPC client doesn't work until a connection has been established.
      *
      * @return The Browser Wallet's internal gRPC client.
+     * @throws If the installed version of the Browser Wallet doesn't support the method.
      */
     getGrpcClient() {
         return this.client.getGrpcClient();

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -90,6 +90,22 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         return this.client.getJsonRpcClient();
     }
 
+    /**
+     * Returns a gRPC client that is ready to perform requests against some Concordium Node connected to network/chain
+     * that the connected account lives on.
+     * The client implements version 2 of the Node's API.
+     *
+     * This method is included because it's part of the Browser Wallet's API.
+     * It should be used with care as it's hard to guarantee that it actually connects to the expected network.
+     * The recommended alternative is to have the application instantiate its own instance
+     * that is independent of any connection.
+     * See {@link Network.grpcOpts} for more details.
+     *
+     * Note that this method cannot be moved to {@link WalletConnector} as the Browser Wallet's RPC client doesn't work
+     * until a connection has been established.
+     *
+     * @return The Browser Wallet's internal gRPC client.
+     */
     getGrpcClient() {
         return this.client.getGrpcClient();
     }

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -90,6 +90,10 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         return this.client.getJsonRpcClient();
     }
 
+    getGrpcClient() {
+        return this.client.getGrpcClient();
+    }
+
     /**
      * Deregister event handlers on the API client and notify the delegate.
      * As there's no way to actually disconnect the Browser Wallet, this is all that we can reasonably do.

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -365,7 +365,7 @@ export class WalletConnectConnector implements WalletConnector {
     }
 
     async connect() {
-        const { name, jsonRpcUrl} = this.network;
+        const { name, jsonRpcUrl } = this.network;
 
         const chainId = `${WALLET_CONNECT_SESSION_NAMESPACE}:${name}`;
         const session = await new Promise<SessionTypes.Struct | undefined>((resolve) => {

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -212,7 +212,7 @@ export class WalletConnectConnection implements WalletConnection {
 
     getJsonRpcClient() {
         if (!this.jsonRpcClient) {
-            throw new Error('no JSON RPC URL provided to network configuration');
+            throw new Error('no JSON RPC URL provided in network configuration');
         }
         return this.jsonRpcClient;
     }

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -3,10 +3,12 @@ import { SendTransactionPayload, SmartContractParameters } from '@concordium/bro
 import {
     AccountTransactionSignature,
     AccountTransactionType,
+    ConcordiumGRPCClient,
     JsonRpcClient,
     SchemaVersion,
     toBuffer,
 } from '@concordium/web-sdk';
+import { GrpcWebOptions } from '@protobuf-ts/grpcweb-transport';
 
 export type ModuleSchema = {
     type: 'ModuleSchema';
@@ -152,6 +154,7 @@ export interface WalletConnection {
     /**
      * Returns a JSON-RPC client that is ready to perform requests against some Concordium Node connected to network/chain
      * that the connected account lives on.
+     * The client implements version 1 of the Node's API which is deprecated. Prefer using {@link getGrpcClient} instead.
      *
      * This method is included because it's part of the Browser Wallet's API.
      * It should be used with care as it's hard to guarantee that it actually connects to the expected network.
@@ -160,10 +163,28 @@ export interface WalletConnection {
      * Note that this method cannot be moved to {@link WalletConnector} as the Browser Wallet's RPC client doesn't work
      * until a connection has been established.
      *
-     * @return Returns a JSON-RPC client for performing requests against a Concordium Node connected
-     * to the appropriate network.
+     * @return A JSON-RPC client for performing requests against a Concordium Node connected to the appropriate network.
+     * @throws If the connection uses {@link Network.jsonRpcUrl} and that value is undefined.
+     * @deprecated Use {@link getGrpcClient} instead.
      */
     getJsonRpcClient(): JsonRpcClient;
+
+    /**
+     * Returns a gRPC client that is ready to perform requests against some Concordium Node connected to network/chain
+     * that the connected account lives on.
+     * The client implements version 2 of the Node's API and is preferred over {@link getJsonRpcClient}.
+     *
+     * This method is included because it's part of the Browser Wallet's API.
+     * It should be used with care as it's hard to guarantee that it actually connects to the expected network.
+     * The application may easily instantiate its own client and use that instead for more control.
+     *
+     * Note that this method cannot be moved to {@link WalletConnector} as the Browser Wallet's RPC client doesn't work
+     * until a connection has been established.
+     *
+     * @return A gRPC client for performing requests against a Concordium Node connected to the appropriate network.
+     * @throws If the connection uses {@link Network.grpcOpts} and that value is undefined.
+     */
+    getGrpcClient(): ConcordiumGRPCClient;
 
     /**
      * Assembles a transaction and sends it off to the wallet for approval and submission.
@@ -227,10 +248,51 @@ export interface Network {
     genesisHash: string;
 
     /**
+     * The connection configuration for a gRPC Web endpoint for performing API (v2) queries against a
+     * Concordium Node instance connected to this network.
+     *
+     * The value is currently used only for {@link WalletConnectConnection WalletConnect connections}
+     * as {@link BrowserWalletConnector Browser Wallet connections} use the Browser Wallet's internal client.
+     *
+     * Making the field undefined disables the automatic initialization of the client for WalletConnect connections.
+     * Instead of returning a client instance, {@link WalletConnectConnection.getGrpcClient} will throw an exception
+     * in this case.
+     *
+     * There's no fundamental difference between using a manually configured client compared to the one belonging to the connections.
+     * Keeping it separate from connection puts the dApp in control and also allows it to use the client
+     * before any connections have been established.
+     * The initialization is straightforward:
+     * <pre>
+     *   import { ConcordiumGRPCClient } from '@concordium/web-sdk';
+     *   import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
+     *   ...
+     *   const client = new ConcordiumGRPCClient(new GrpcWebFetchTransport(network.grpcOpts!));
+     * </pre>
+     */
+    grpcOpts: GrpcWebOptions | undefined;
+
+    /**
      * The URL of a <a href="https://github.com/Concordium/concordium-json-rpc">Concordium JSON-RPC proxy</a> instance
      * for performing API (v1) queries against a Concordium Node instance connected to this network.
+     *
+     * The value is currently used only for {@link WalletConnectConnection WalletConnect connections}
+     * as {@link BrowserWalletConnector Browser Wallet connections} use the Browser Wallet's internal client.
+     *
+     * Making the field undefined disables the automatic initialization of the client for WalletConnect connections.
+     * Instead of returning a client instance, {@link WalletConnectConnection.getJsonRpcClient} will throw an exception
+     * in this case.
+     *
+     * There's no fundamental difference between using a manually configured client compared to the one belonging to the connections.
+     * Keeping it separate from connection puts the dApp in control and also allows it to use the client
+     * before any connections have been established.
+     * The initialization is straightforward:
+     * <pre>
+     *   import { HttpProvider, JsonRpcClient } from '@concordium/web-sdk';
+     *   ...
+     *   const client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl!));
+     * </pre>
      */
-    jsonRpcUrl: string;
+    jsonRpcUrl: string | undefined;
 
     /**
      * The base URL of a <a href="https://github.com/Concordium/concordium-scan">CCDScan</a> instance

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -158,13 +158,14 @@ export interface WalletConnection {
      *
      * This method is included because it's part of the Browser Wallet's API.
      * It should be used with care as it's hard to guarantee that it actually connects to the expected network.
-     * The application may easily instantiate its own client and use that instead for more control.
+     * As explained in {@link Network.jsonRpcUrl}, the application may easily instantiate its own client and use that instead.
      *
-     * Note that this method cannot be moved to {@link WalletConnector} as the Browser Wallet's RPC client doesn't work
-     * until a connection has been established.
+     * Implementation detail: The method cannot be moved to {@link WalletConnector}
+     * as the Browser Wallet's internal client doesn't work until a connection has been established.
      *
      * @return A JSON-RPC client for performing requests against a Concordium Node connected to the appropriate network.
      * @throws If the connection uses {@link Network.jsonRpcUrl} and that value is undefined.
+     * @throws If the connection is to the Browser Wallet and the installed version doesn't support the method.
      * @deprecated Use {@link getGrpcClient} instead.
      */
     getJsonRpcClient(): JsonRpcClient;
@@ -174,15 +175,17 @@ export interface WalletConnection {
      * that the connected account lives on.
      * The client implements version 2 of the Node's API and is preferred over {@link getJsonRpcClient}.
      *
-     * This method is included because it's part of the Browser Wallet's API.
+     * This method is included because it's part of the Browser Wallet's API to ensure that one uses the same backend as the wallet.
      * It should be used with care as it's hard to guarantee that it actually connects to the expected network.
-     * The application may easily instantiate its own client and use that instead for more control.
+     * As the mobile wallets don't currently use gRPC, the implementation for WalletConnect connections create their own local client.
+     * As explained in {@link Network.grpcOpts}, the application may easily instantiate its own client and use that instead.
      *
-     * Note that this method cannot be moved to {@link WalletConnector} as the Browser Wallet's RPC client doesn't work
-     * until a connection has been established.
+     * Implementation detail: The method cannot be moved to {@link WalletConnector}
+     * as the Browser Wallet's internal client doesn't work until a connection has been established.
      *
      * @return A gRPC client for performing requests against a Concordium Node connected to the appropriate network.
      * @throws If the connection uses {@link Network.grpcOpts} and that value is undefined.
+     * @throws If the connection is to the Browser Wallet and the installed version doesn't support the method.
      */
     getGrpcClient(): ConcordiumGRPCClient;
 

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -167,9 +167,7 @@ export interface WalletConnection {
      * The method {@link BrowserWalletConnector.getGrpcClient} exists for exposing the wallet's internal gRPC Web client for API version 2,
      * but it's not recommended for use in most cases as there's no need for the client to be associated with a particular connection.
      *
-     * Instead, instantiate the client manually as described in {@link Network.grpcOpts}.
-     * For React projects, the hook <code>useGrpcClient</code> in {@link https://www.npmjs.com/package/@concordium/react-components @concordium/react-components}.
-     * makes it very easy to obtain a client that's always connecting to the expected network.
+     * Instead, instantiate the client manually or using a hook (for React) as described in {@link Network.grpcOpts}.
      *
      * @return A JSON-RPC client for performing requests against a Concordium Node connected to the appropriate network.
      * @throws If the connection uses {@link Network.jsonRpcUrl} and that value is undefined.
@@ -250,6 +248,10 @@ export interface Network {
      *   ...
      *   const client = new ConcordiumGRPCClient(new GrpcWebFetchTransport(network.grpcOpts!));
      * </pre>
+     *
+     * For React projects, the hook <code>useGrpcClient</code> in
+     * {@link https://www.npmjs.com/package/@concordium/react-components @concordium/react-components}
+     * makes it very easy to obtain a client that's always connecting to the expected network.
      */
     grpcOpts: GrpcWebOptions | undefined;
 
@@ -260,9 +262,10 @@ export interface Network {
      * The value is currently used only for {@link WalletConnectConnection WalletConnect connections}
      * as {@link BrowserWalletConnector Browser Wallet connections} use the Browser Wallet's internal client.
      *
-     * Setting the URL to the empty string disables the automatic initialization of the client for WalletConnect connections.
-     * Instead of returning a client instance, {@link WalletConnectConnection.getJsonRpcClient} will throw an exception
-     * in this case.
+     * Setting the URL to the empty string disables the automatic initialization of the client returned by
+     * {@link WalletConnection.getJsonRpcClient} for WalletConnect connections.
+     * Instead of returning a client instance,
+     * the concrete implementation {@link WalletConnectConnection.getJsonRpcClient} will throw an exception in this case.
      *
      * There's no fundamental difference between using a manually configured client compared to the one belonging to the connections.
      * Keeping it separate from connection puts the dApp in control and also allows it to use the client

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -256,7 +256,7 @@ export interface Network {
     grpcOpts: GrpcWebOptions | undefined;
 
     /**
-     * The URL of a <a href="https://github.com/Concordium/concordium-json-rpc">Concordium JSON-RPC proxy</a> instance
+     * The URL of a {@link https://github.com/Concordium/concordium-json-rpc Concordium JSON-RPC proxy} instance
      * for performing API (v1) queries against a Concordium Node instance connected to this network.
      *
      * The value is currently used only for {@link WalletConnectConnection WalletConnect connections}
@@ -264,13 +264,13 @@ export interface Network {
      *
      * Setting the URL to the empty string disables the automatic initialization of the client returned by
      * {@link WalletConnection.getJsonRpcClient} for WalletConnect connections.
-     * Instead of returning a client instance,
-     * the concrete implementation {@link WalletConnectConnection.getJsonRpcClient} will throw an exception in this case.
+     * The concrete implementation {@link WalletConnectConnection.getJsonRpcClient} will then throw an exception
+     * as there is no client instance to return.
      *
-     * There's no fundamental difference between using a manually configured client compared to the one belonging to the connections.
-     * Keeping it separate from connection puts the dApp in control and also allows it to use the client
-     * before any connections have been established.
-     * The initialization is straightforward:
+     * There is no fundamental difference between using a client belonging to a connection compared to one that is initialized directly.
+     * Keeping it separate from connections gives the dApp more control and allows the client to be used even if no connections have been established.
+     *
+     * Initializing a separate client is straightforward:
      * <pre>
      *   import { HttpProvider, JsonRpcClient } from '@concordium/web-sdk';
      *   ...
@@ -280,7 +280,7 @@ export interface Network {
     jsonRpcUrl: string;
 
     /**
-     * The base URL of a <a href="https://github.com/Concordium/concordium-scan">CCDScan</a> instance
+     * The base URL of a {@link https://github.com/Concordium/concordium-scan CCDScan} instance
      * connected to this network.
      * While CCDScan supports queries against its backend,
      * the main use of this URL is to construct links to the frontend.

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -153,15 +153,6 @@ export interface WalletConnection {
     /**
      * Returns a JSON-RPC client that is ready to perform requests against some Concordium Node connected to network/chain
      * that the connected account lives on.
-     * The client implements version 1 of the Node's API which is deprecated in favor of
-     * {@link https://www.npmjs.com/package/@concordium/web-sdk#ConcordiumNodeClient ConcordiumGRPCClient}
-     * from <code>@concordium/web-sdk</code>.
-     *
-     * The method {@link BrowserWalletConnector.getGrpcClient} exists for exposing the wallet's internal gRPC Web client for API version 2,
-     * but it's not recommended for common cases as there's no reason for the client to be associated with a particular connection.
-     *
-     * The hook <code>useGrpcClient</code> in <code>@concordium/react-libraries</code>
-     * makes it very easy to instantiate a client connected to the appropriate network in React projects.
      *
      * This method is included because it's part of the Browser Wallet's API.
      * It should be used with care as it's hard to guarantee that it actually connects to the expected network.
@@ -170,10 +161,20 @@ export interface WalletConnection {
      * Implementation detail: The method cannot be moved to {@link WalletConnector}
      * as the Browser Wallet's internal client doesn't work until a connection has been established.
      *
+     * The client implements version 1 of the Node's API which is deprecated in favor of
+     * <code>ConcordiumGRPCClient</code> from {@link https://www.npmjs.com/package/@concordium/web-sdk @concordium/web-sdk}.
+     *
+     * The method {@link BrowserWalletConnector.getGrpcClient} exists for exposing the wallet's internal gRPC Web client for API version 2,
+     * but it's not recommended for use in most cases as there's no need for the client to be associated with a particular connection.
+     *
+     * Instead, instantiate the client manually as described in {@link Network.grpcOpts}.
+     * For React projects, the hook <code>useGrpcClient</code> in {@link https://www.npmjs.com/package/@concordium/react-components @concordium/react-components}.
+     * makes it very easy to obtain a client that's always connecting to the expected network.
+     *
      * @return A JSON-RPC client for performing requests against a Concordium Node connected to the appropriate network.
      * @throws If the connection uses {@link Network.jsonRpcUrl} and that value is undefined.
      * @throws If the connection is to the Browser Wallet and the installed version doesn't support the method.
-     * @deprecated Use {@link getGrpcClient} instead.
+     * @deprecated Use <code>ConcordiumGRPCClient<code> instead.
      */
     getJsonRpcClient(): JsonRpcClient;
 
@@ -270,7 +271,7 @@ export interface Network {
      * <pre>
      *   import { HttpProvider, JsonRpcClient } from '@concordium/web-sdk';
      *   ...
-     *   const client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl!));
+     *   const client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl));
      * </pre>
      */
     jsonRpcUrl: string;

--- a/packages/wallet-connectors/src/WalletConnection.ts
+++ b/packages/wallet-connectors/src/WalletConnection.ts
@@ -154,7 +154,7 @@ export interface WalletConnection {
      * Returns a JSON-RPC client that is ready to perform requests against some Concordium Node connected to network/chain
      * that the connected account lives on.
      *
-     * This method is included because it's part of the Browser Wallet's API.
+     * This method is included because it's part of the Browser Wallet API.
      * It should be used with care as it's hard to guarantee that it actually connects to the expected network.
      * As explained in {@link Network.jsonRpcUrl}, the application may easily instantiate its own client and use that instead.
      *

--- a/packages/wallet-connectors/src/index.ts
+++ b/packages/wallet-connectors/src/index.ts
@@ -21,7 +21,7 @@ export const TESTNET: Network = {
     name: 'testnet',
     genesisHash: TESTNET_GENESIS_BLOCK_HASH,
     grpcOpts: {
-        baseUrl: 'https://grpc.testnet.concordium.com',
+        baseUrl: 'https://grpc.testnet.concordium.com:20000',
     },
     jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
     ccdScanBaseUrl: 'https://testnet.ccdscan.io',
@@ -34,7 +34,7 @@ export const MAINNET: Network = {
     name: 'mainnet',
     genesisHash: MAINNET_GENESIS_BLOCK_HASH,
     grpcOpts: {
-        baseUrl: 'https://grpc.mainnet.concordium.software',
+        baseUrl: 'https://grpc.mainnet.concordium.software:20000',
     },
     jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software',
     ccdScanBaseUrl: 'https://ccdscan.io',

--- a/packages/wallet-connectors/src/index.ts
+++ b/packages/wallet-connectors/src/index.ts
@@ -1,3 +1,5 @@
+import { Network } from './WalletConnection';
+
 export * from './WalletConnection';
 export * from './WalletConnect';
 export * from './BrowserWallet';
@@ -8,3 +10,32 @@ export * from './BrowserWallet';
  * or one of a project in their own account.
  */
 export const CONCORDIUM_WALLET_CONNECT_PROJECT_ID = '76324905a70fe5c388bab46d3e0564dc';
+
+const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
+const MAINNET_GENESIS_BLOCK_HASH = '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
+
+/**
+ * Standard configuration for the Testnet network.
+ */
+export const TESTNET: Network = {
+    name: 'testnet',
+    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
+    grpcOpts: {
+        baseUrl: 'https://grpc.testnet.concordium.com',
+    },
+    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
+    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
+};
+
+/**
+ * Standard configuration for the Mainnet network.
+ */
+export const MAINNET: Network = {
+    name: 'mainnet',
+    genesisHash: MAINNET_GENESIS_BLOCK_HASH,
+    grpcOpts: {
+        baseUrl: 'https://grpc.mainnet.concordium.software',
+    },
+    jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software',
+    ccdScanBaseUrl: 'https://ccdscan.io',
+};

--- a/samples/contractupdate/src/App.tsx
+++ b/samples/contractupdate/src/App.tsx
@@ -4,16 +4,18 @@ import { Network, WalletConnection } from '@concordium/react-components';
 import { useContractSelector } from '@concordium/react-components';
 import { ContractDetails } from './ContractDetails';
 import { ContractInvoker } from './ContractInvoker';
+import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 
 interface Props {
     network: Network;
+    rpcClient: ConcordiumGRPCClient | undefined;
     connection: WalletConnection | undefined;
     connectedAccount: string | undefined;
 }
 
-export function App({ network, connection, connectedAccount }: Props) {
+export function App({ network, rpcClient, connection, connectedAccount }: Props) {
     const [input, setInput] = useState('');
-    const contract = useContractSelector(connection?.getJsonRpcClient(), input);
+    const contract = useContractSelector(rpcClient, input);
     return (
         <>
             {connection && (

--- a/samples/contractupdate/src/App.tsx
+++ b/samples/contractupdate/src/App.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import { Col, Form, Row, Spinner } from 'react-bootstrap';
 import { Network, WalletConnection } from '@concordium/react-components';
 import { useContractSelector } from '@concordium/react-components';
+import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 import { ContractDetails } from './ContractDetails';
 import { ContractInvoker } from './ContractInvoker';
-import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 
 interface Props {
     network: Network;

--- a/samples/contractupdate/src/App.tsx
+++ b/samples/contractupdate/src/App.tsx
@@ -8,14 +8,14 @@ import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 
 interface Props {
     network: Network;
-    rpcClient: ConcordiumGRPCClient | undefined;
+    rpc: ConcordiumGRPCClient | undefined;
     connection: WalletConnection | undefined;
     connectedAccount: string | undefined;
 }
 
-export function App({ network, rpcClient, connection, connectedAccount }: Props) {
+export function App({ network, rpc, connection, connectedAccount }: Props) {
     const [input, setInput] = useState('');
-    const contract = useContractSelector(rpcClient, input);
+    const contract = useContractSelector(rpc, input);
     return (
         <>
             {connection && (

--- a/samples/contractupdate/src/ConnectedAccount.tsx
+++ b/samples/contractupdate/src/ConnectedAccount.tsx
@@ -6,7 +6,7 @@ import { errorString } from './util';
 
 interface Props {
     network: Network;
-    rpcClient: ConcordiumGRPCClient | undefined;
+    rpc: ConcordiumGRPCClient | undefined;
     account: string | undefined;
 }
 
@@ -14,13 +14,13 @@ function ccdScanUrl(network: Network, activeConnectedAccount: string | undefined
     return `${network.ccdScanBaseUrl}/?dcount=1&dentity=account&daddress=${activeConnectedAccount}`;
 }
 
-export function ConnectedAccount({ network, rpcClient, account }: Props) {
+export function ConnectedAccount({ network, rpc, account }: Props) {
     const [info, setInfo] = useState<AccountInfo>();
     const [infoError, setInfoError] = useState('');
     useEffect(() => {
-        if (rpcClient && account) {
+        if (rpc && account) {
             setInfo(undefined);
-            rpcClient
+            rpc
                 .getAccountInfo(new AccountAddress(account))
                 .then((res) => {
                     setInfo(res);
@@ -31,7 +31,7 @@ export function ConnectedAccount({ network, rpcClient, account }: Props) {
                     setInfoError(errorString(err));
                 });
         }
-    }, [rpcClient, account]);
+    }, [rpc, account]);
     return (
         <>
             {infoError && <Alert variant="danger">Error querying account info: {infoError}</Alert>}

--- a/samples/contractupdate/src/ConnectedAccount.tsx
+++ b/samples/contractupdate/src/ConnectedAccount.tsx
@@ -20,8 +20,7 @@ export function ConnectedAccount({ network, rpc, account }: Props) {
     useEffect(() => {
         if (rpc && account) {
             setInfo(undefined);
-            rpc
-                .getAccountInfo(new AccountAddress(account))
+            rpc.getAccountInfo(new AccountAddress(account))
                 .then((res) => {
                     setInfo(res);
                     setInfoError('');

--- a/samples/contractupdate/src/ConnectedAccount.tsx
+++ b/samples/contractupdate/src/ConnectedAccount.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Alert } from 'react-bootstrap';
-import { Network, WalletConnection } from '@concordium/react-components';
-import { AccountAddress, AccountInfo } from '@concordium/web-sdk';
+import { Network } from '@concordium/react-components';
+import { AccountAddress, AccountInfo, ConcordiumGRPCClient } from '@concordium/web-sdk';
 import { errorString } from './util';
 
 interface Props {
     network: Network;
-    connection: WalletConnection | undefined;
+    rpcClient: ConcordiumGRPCClient | undefined;
     account: string | undefined;
 }
 
@@ -14,14 +14,13 @@ function ccdScanUrl(network: Network, activeConnectedAccount: string | undefined
     return `${network.ccdScanBaseUrl}/?dcount=1&dentity=account&daddress=${activeConnectedAccount}`;
 }
 
-export function ConnectedAccount({ connection, account, network }: Props) {
+export function ConnectedAccount({ network, rpcClient, account }: Props) {
     const [info, setInfo] = useState<AccountInfo>();
     const [infoError, setInfoError] = useState('');
     useEffect(() => {
-        if (connection && account) {
+        if (rpcClient && account) {
             setInfo(undefined);
-            connection
-                .getGrpcClient()
+            rpcClient
                 .getAccountInfo(new AccountAddress(account))
                 .then((res) => {
                     setInfo(res);
@@ -32,7 +31,7 @@ export function ConnectedAccount({ connection, account, network }: Props) {
                     setInfoError(errorString(err));
                 });
         }
-    }, [connection, account]);
+    }, [rpcClient, account]);
     return (
         <>
             {infoError && <Alert variant="danger">Error querying account info: {infoError}</Alert>}

--- a/samples/contractupdate/src/ConnectedAccount.tsx
+++ b/samples/contractupdate/src/ConnectedAccount.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Alert } from 'react-bootstrap';
-import { Network, WalletConnection, withJsonRpcClient } from '@concordium/react-components';
-import { AccountInfo } from '@concordium/web-sdk';
+import { Network, WalletConnection } from '@concordium/react-components';
+import { AccountAddress, AccountInfo } from '@concordium/web-sdk';
+import { errorString } from './util';
 
 interface Props {
     network: Network;
@@ -19,14 +20,16 @@ export function ConnectedAccount({ connection, account, network }: Props) {
     useEffect(() => {
         if (connection && account) {
             setInfo(undefined);
-            withJsonRpcClient(connection, (rpc) => rpc.getAccountInfo(account))
+            connection
+                .getGrpcClient()
+                .getAccountInfo(new AccountAddress(account))
                 .then((res) => {
                     setInfo(res);
                     setInfoError('');
                 })
                 .catch((err) => {
                     setInfo(undefined);
-                    setInfoError(err);
+                    setInfoError(errorString(err));
                 });
         }
     }, [connection, account]);

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -30,6 +30,15 @@ function Main(props: WalletConnectionProps) {
     const [rpcError, setRpcError] = useState('');
 
     const { grpcClient } = useGrpcClient(network);
+
+    // For debugging the Browser Wallet client: It looks like the first call always fails...
+    // const [grpcClient, setGrpcClient] = useState<ConcordiumGRPCClient>();
+    // useEffect(() => {
+    //     if (connection && connection instanceof BrowserWalletConnector) {
+    //         setGrpcClient(connection.getGrpcClient());
+    //     }
+    // }, [connection]);
+
     useEffect(() => {
         if (grpcClient) {
             setRpcGenesisHash(undefined);

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Button, Col, Container, Row, Spinner } from 'react-bootstrap';
-import { withJsonRpcClient } from '@concordium/react-components';
-import { WalletConnectionProps, WithWalletConnector, MAINNET, TESTNET } from '@concordium/react-components';
+import { MAINNET, TESTNET, WalletConnectionProps, WithWalletConnector } from '@concordium/react-components';
 import { useConnection } from '@concordium/react-components';
 import { useConnect } from '@concordium/react-components';
 import { App } from './App';
@@ -33,10 +32,10 @@ function Main(props: WalletConnectionProps) {
     useEffect(() => {
         if (connection) {
             setRpcGenesisHash(undefined);
-            withJsonRpcClient(connection, async (rpc) => {
-                const status = await rpc.getConsensusStatus();
-                return status.genesisBlock;
-            })
+            connection
+                .getGrpcClient()
+                .getConsensusStatus()
+                .then((status) => status.genesisBlock)
                 .then((hash) => {
                     setRpcGenesisHash(hash);
                     setRpcError('');

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Button, Col, Container, Row, Spinner } from 'react-bootstrap';
 import { withJsonRpcClient } from '@concordium/react-components';
-import { WalletConnectionProps, WithWalletConnector } from '@concordium/react-components';
+import { WalletConnectionProps, WithWalletConnector, MAINNET, TESTNET } from '@concordium/react-components';
 import { useConnection } from '@concordium/react-components';
 import { useConnect } from '@concordium/react-components';
 import { App } from './App';
 import { ConnectedAccount } from './ConnectedAccount';
 import { NetworkSelector } from './NetworkSelector';
 import { WalletConnectorButton } from './WalletConnectorButton';
-import { BROWSER_WALLET, MAINNET, TESTNET, WALLET_CONNECT } from './config';
+import { BROWSER_WALLET, WALLET_CONNECT } from './config';
 import { errorString } from './util';
 
 export default function Root() {

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -28,12 +28,11 @@ function Main(props: WalletConnectionProps) {
 
     const [rpcGenesisHash, setRpcGenesisHash] = useState<string>();
     const [rpcError, setRpcError] = useState('');
-    const { grpcClient } = useGrpcClient(network);
+    const rpc = useGrpcClient(network);
     useEffect(() => {
-        if (grpcClient) {
+        if (rpc) {
             setRpcGenesisHash(undefined);
-            grpcClient
-                .getConsensusStatus()
+            rpc.getConsensusStatus()
                 .then((status) => status.genesisBlock)
                 .then((hash) => {
                     setRpcGenesisHash(hash);
@@ -44,7 +43,7 @@ function Main(props: WalletConnectionProps) {
                     setRpcError(errorString(err));
                 });
         }
-    }, [grpcClient]);
+    }, [rpc]);
     return (
         <>
             <Row className="mt-3 mb-3">
@@ -81,7 +80,7 @@ function Main(props: WalletConnectionProps) {
             </Row>
             <Row className="mt-3 mb-3">
                 <Col>
-                    <ConnectedAccount network={network} rpc={grpcClient} account={account} />
+                    <ConnectedAccount network={network} rpc={rpc} account={account} />
                 </Col>
             </Row>
             <Row className="mt-3 mb-3">
@@ -94,7 +93,7 @@ function Main(props: WalletConnectionProps) {
                         />
                     )}
                     {rpcError && <Alert variant="warning">RPC error: {rpcError}</Alert>}
-                    <App network={network} rpc={grpcClient} connection={connection} connectedAccount={account} />
+                    <App network={network} rpc={rpc} connection={connection} connectedAccount={account} />
                 </Col>
             </Row>
         </>

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -28,17 +28,7 @@ function Main(props: WalletConnectionProps) {
 
     const [rpcGenesisHash, setRpcGenesisHash] = useState<string>();
     const [rpcError, setRpcError] = useState('');
-
     const { grpcClient } = useGrpcClient(network);
-
-    // For debugging the Browser Wallet client: It looks like the first call always fails...
-    // const [grpcClient, setGrpcClient] = useState<ConcordiumGRPCClient>();
-    // useEffect(() => {
-    //     if (connection && connection instanceof BrowserWalletConnector) {
-    //         setGrpcClient(connection.getGrpcClient());
-    //     }
-    // }, [connection]);
-
     useEffect(() => {
         if (grpcClient) {
             setRpcGenesisHash(undefined);

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Button, Col, Container, Row, Spinner } from 'react-bootstrap';
 import { MAINNET, TESTNET, WalletConnectionProps, WithWalletConnector } from '@concordium/react-components';
-import { useConnection } from '@concordium/react-components';
-import { useConnect } from '@concordium/react-components';
+import { useConnect, useConnection, useGrpcClient } from '@concordium/react-components';
 import { App } from './App';
 import { ConnectedAccount } from './ConnectedAccount';
 import { NetworkSelector } from './NetworkSelector';
@@ -29,11 +28,12 @@ function Main(props: WalletConnectionProps) {
 
     const [rpcGenesisHash, setRpcGenesisHash] = useState<string>();
     const [rpcError, setRpcError] = useState('');
+
+    const { grpcClient } = useGrpcClient(network);
     useEffect(() => {
-        if (connection) {
+        if (grpcClient) {
             setRpcGenesisHash(undefined);
-            connection
-                .getGrpcClient()
+            grpcClient
                 .getConsensusStatus()
                 .then((status) => status.genesisBlock)
                 .then((hash) => {
@@ -45,7 +45,7 @@ function Main(props: WalletConnectionProps) {
                     setRpcError(errorString(err));
                 });
         }
-    }, [connection, genesisHash, network]);
+    }, [grpcClient]);
     return (
         <>
             <Row className="mt-3 mb-3">
@@ -82,7 +82,7 @@ function Main(props: WalletConnectionProps) {
             </Row>
             <Row className="mt-3 mb-3">
                 <Col>
-                    <ConnectedAccount connection={connection} account={account} network={network} />
+                    <ConnectedAccount network={network} rpcClient={grpcClient} account={account} />
                 </Col>
             </Row>
             <Row className="mt-3 mb-3">
@@ -95,7 +95,7 @@ function Main(props: WalletConnectionProps) {
                         />
                     )}
                     {rpcError && <Alert variant="warning">RPC error: {rpcError}</Alert>}
-                    <App network={network} connection={connection} connectedAccount={account} />
+                    <App network={network} rpcClient={grpcClient} connection={connection} connectedAccount={account} />
                 </Col>
             </Row>
         </>

--- a/samples/contractupdate/src/Root.tsx
+++ b/samples/contractupdate/src/Root.tsx
@@ -82,7 +82,7 @@ function Main(props: WalletConnectionProps) {
             </Row>
             <Row className="mt-3 mb-3">
                 <Col>
-                    <ConnectedAccount network={network} rpcClient={grpcClient} account={account} />
+                    <ConnectedAccount network={network} rpc={grpcClient} account={account} />
                 </Col>
             </Row>
             <Row className="mt-3 mb-3">
@@ -95,7 +95,7 @@ function Main(props: WalletConnectionProps) {
                         />
                     )}
                     {rpcError && <Alert variant="warning">RPC error: {rpcError}</Alert>}
-                    <App network={network} rpcClient={grpcClient} connection={connection} connectedAccount={account} />
+                    <App network={network} rpc={grpcClient} connection={connection} connectedAccount={account} />
                 </Col>
             </Row>
         </>

--- a/samples/contractupdate/src/config.ts
+++ b/samples/contractupdate/src/config.ts
@@ -1,27 +1,10 @@
 import {
     BrowserWalletConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
-    Network,
     WalletConnectConnector,
     ephemeralConnectorType,
 } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
-
-const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
-const MAINNET_GENESIS_BLOCK_HASH = '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
-
-export const TESTNET: Network = {
-    name: 'testnet',
-    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
-    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
-    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
-};
-export const MAINNET: Network = {
-    name: 'mainnet',
-    genesisHash: MAINNET_GENESIS_BLOCK_HASH,
-    jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software',
-    ccdScanBaseUrl: 'https://ccdscan.io',
-};
 
 const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
     projectId: CONCORDIUM_WALLET_CONNECT_PROJECT_ID,

--- a/samples/sign-message/src/App.tsx
+++ b/samples/sign-message/src/App.tsx
@@ -9,10 +9,10 @@ import {
     typeSchemaFromBase64,
     useConnect,
     useConnection,
+    TESTNET,
 } from '@concordium/react-components';
 import { AccountTransactionSignature } from '@concordium/web-sdk';
 import { WalletConnectorButton } from './WalletConnectorButton';
-import { TESTNET } from './config';
 import { BROWSER_WALLET, WALLET_CONNECT } from './config';
 import { errorString } from './util';
 

--- a/samples/sign-message/src/App.tsx
+++ b/samples/sign-message/src/App.tsx
@@ -2,6 +2,7 @@ import { ResultAsync, err, ok } from 'neverthrow';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Alert, Button, Col, Container, Form, InputGroup, Row, Spinner } from 'react-bootstrap';
 import {
+    TESTNET,
     WalletConnectionProps,
     WithWalletConnector,
     binaryMessageFromHex,
@@ -9,7 +10,6 @@ import {
     typeSchemaFromBase64,
     useConnect,
     useConnection,
-    TESTNET,
 } from '@concordium/react-components';
 import { AccountTransactionSignature } from '@concordium/web-sdk';
 import { WalletConnectorButton } from './WalletConnectorButton';

--- a/samples/sign-message/src/config.ts
+++ b/samples/sign-message/src/config.ts
@@ -1,27 +1,10 @@
 import {
     BrowserWalletConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
-    Network,
     WalletConnectConnector,
     ephemeralConnectorType,
 } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
-
-const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
-const MAINNET_GENESIS_BLOCK_HASH = '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
-
-export const TESTNET: Network = {
-    name: 'testnet',
-    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
-    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
-    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
-};
-export const MAINNET: Network = {
-    name: 'mainnet',
-    genesisHash: MAINNET_GENESIS_BLOCK_HASH,
-    jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software',
-    ccdScanBaseUrl: 'https://ccdscan.io',
-};
 
 const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
     projectId: CONCORDIUM_WALLET_CONNECT_PROJECT_ID,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,20 +1621,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/browser-wallet-api-helpers@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@concordium/browser-wallet-api-helpers@npm:2.4.0"
+"@concordium/browser-wallet-api-helpers@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@concordium/browser-wallet-api-helpers@npm:2.5.0"
   dependencies:
-    "@concordium/web-sdk": ^3.4.0
-  checksum: 3c518068034e7e0ddd9b2932339bb198a64f77c1bc79989323514edb687be37a2505bb792b2b59775fee819bb7f995a8f57a183b9e09a129a04589cd511f7cc4
+    "@concordium/web-sdk": ^3.4.2
+  checksum: 9ec96012fa9f81b1cc5e611485bf4a474c98def713c406a5d621e7047f503511aebb9d9890b2874b857a185a49d22d37c0eb748e881691cd24624d1a1f087fb1
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@npm:6.4.1":
-  version: 6.4.1
-  resolution: "@concordium/common-sdk@npm:6.4.1"
+"@concordium/common-sdk@npm:6.5.0":
+  version: 6.5.0
+  resolution: "@concordium/common-sdk@npm:6.5.0"
   dependencies:
-    "@concordium/rust-bindings": 0.11.0
+    "@concordium/rust-bindings": 0.11.1
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/runtime-rpc": ^2.8.2
@@ -1646,7 +1646,7 @@ __metadata:
     iso-3166-1: ^2.1.1
     json-bigint: ^1.0.0
     uuid: ^8.3.2
-  checksum: 26cce68b496f9799359666d7ddf430c659c0250e16a96c8bfe1956162f737517896a9ab9e0c9a7a3a17117ee6d763a91cbcde20891c76d87444f67299a37c8c6
+  checksum: daf7e586b5fd89a4f2e84c602b9ffdbe5215a176b6673aa42abf7c54d722f5380f716672100f6a68c321ba97b87c381476bce768ff1e5299b5d07c6ded96e716
   languageName: node
   linkType: hard
 
@@ -1665,10 +1665,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@concordium/rust-bindings@npm:0.11.0":
-  version: 0.11.0
-  resolution: "@concordium/rust-bindings@npm:0.11.0"
-  checksum: a6c437cb782b7b2e9f217215dd4dbed9ffb8b3ef46fa307952aca3ae8f166cb96687de64efd18490aec7e86d58712dccb7d1a8bf63c151e3ed2a0170f066cd6d
+"@concordium/rust-bindings@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@concordium/rust-bindings@npm:0.11.1"
+  checksum: fe1bbcd0a98a7e148cfe9fa5ec69a693b19608b64b01723aedd9a7616958d5069cef006f8dfa610f7fad3cd3e8d356c99c76ff2606ea44d90138a43897118277
   languageName: node
   linkType: hard
 
@@ -1676,7 +1676,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/wallet-connectors@workspace:packages/wallet-connectors"
   dependencies:
-    "@concordium/browser-wallet-api-helpers": ^2.4.0
+    "@concordium/browser-wallet-api-helpers": ^2.5.0
     "@tsconfig/recommended": ^1.0.1
     "@walletconnect/qrcode-modal": ^1.8.0
     "@walletconnect/sign-client": ^2.1.4
@@ -1686,17 +1686,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@concordium/web-sdk@npm:^3.4.0":
-  version: 3.4.1
-  resolution: "@concordium/web-sdk@npm:3.4.1"
+"@concordium/web-sdk@npm:^3.4.2":
+  version: 3.5.0
+  resolution: "@concordium/web-sdk@npm:3.5.0"
   dependencies:
-    "@concordium/common-sdk": 6.4.1
-    "@concordium/rust-bindings": 0.11.0
+    "@concordium/common-sdk": 6.5.0
+    "@concordium/rust-bindings": 0.11.1
     "@grpc/grpc-js": ^1.3.4
     "@protobuf-ts/grpcweb-transport": ^2.8.2
     buffer: ^6.0.3
     process: ^0.11.10
-  checksum: 816f565c5eed12ec7f5aad07f2bd5be342ca53ff1f0e5412eab897eccd77562bfefc18906223c59916915686925d89d725bd2dc7520175ea51cb74471b11087c
+  checksum: 681cfdb2533bba93ac62f44b0fcf5596a0fd89a5895085e3e6a416fa162bc1d22ac3bc1a6f8b89a196c46e89e9fd6401c25c493079f406bf8dfa9c6a7eb0aaa7
   languageName: node
   linkType: hard
 
@@ -1899,27 +1899,27 @@ __metadata:
   linkType: hard
 
 "@grpc/grpc-js@npm:^1.3.4":
-  version: 1.8.13
-  resolution: "@grpc/grpc-js@npm:1.8.13"
+  version: 1.8.14
+  resolution: "@grpc/grpc-js@npm:1.8.14"
   dependencies:
     "@grpc/proto-loader": ^0.7.0
     "@types/node": ">=12.12.47"
-  checksum: bc74a6aa4c677ec7824c26f94b9270cab2489b2ebe9731d8acc2a15e882b6d2a9d20e1205938862fc20296e9784a33b0818427e426718ebdd123e621041fd26c
+  checksum: 7b889ae67cde5eb9b4feb92d54e73945d881309b9b879a2dde478fa7850b99835efa7592a8154a0f923851d7a18a177c106f5f52b45061180bb04aef7783c1c9
   languageName: node
   linkType: hard
 
 "@grpc/proto-loader@npm:^0.7.0":
-  version: 0.7.6
-  resolution: "@grpc/proto-loader@npm:0.7.6"
+  version: 0.7.7
+  resolution: "@grpc/proto-loader@npm:0.7.7"
   dependencies:
     "@types/long": ^4.0.1
     lodash.camelcase: ^4.3.0
     long: ^4.0.0
     protobufjs: ^7.0.0
-    yargs: ^16.2.0
+    yargs: ^17.7.2
   bin:
     proto-loader-gen-types: build/bin/proto-loader-gen-types.js
-  checksum: cc42649cf65c74f627ac80b1f3ed275c4cf96dbc27728cc887e91e217c69a3bd6b94dfa7571725a94538d84735af53d35e9583cc77eb65f3c035106216cc4a1b
+  checksum: 6015d99d36d0451075a53e5c5842e8912235973a515677afca038269969ad84f22a4c9fbc9badf52f034736b3f1bf864739f7c4238ba8a7e6fd3bba75cfce0ee
   languageName: node
   linkType: hard
 
@@ -2339,16 +2339,16 @@ __metadata:
   linkType: hard
 
 "@noble/ed25519@npm:^1.7.1":
-  version: 1.7.1
-  resolution: "@noble/ed25519@npm:1.7.1"
-  checksum: b8e50306ac70f5cecc349111997e72e897b47a28d406b96cf95d0ebe7cbdefb8380d26117d7847d94102281db200aa3a494e520f9fc12e2f292e0762cb0fa333
+  version: 1.7.3
+  resolution: "@noble/ed25519@npm:1.7.3"
+  checksum: 45169927d51de513e47bbeebff3a603433c4ac7579e1b8c5034c380a0afedbe85e6959be3d69584a7a5ed6828d638f8f28879003b9bb2fb5f22d8aa2d88fd5fe
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:~1.1.1":
-  version: 1.1.5
-  resolution: "@noble/hashes@npm:1.1.5"
-  checksum: de3f095a7ac1cbf5b4b3d09f193288d4f2eec35fbadf2ed9fd7e47d8a3042fef410052ba62dc0296a185f994c11192f5357fdb1bd9178c905efd82e946c53b00
+"@noble/hashes@npm:~1.3.0":
+  version: 1.3.0
+  resolution: "@noble/hashes@npm:1.3.0"
+  checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
   languageName: node
   linkType: hard
 
@@ -2446,28 +2446,28 @@ __metadata:
   linkType: hard
 
 "@protobuf-ts/grpcweb-transport@npm:^2.8.2":
-  version: 2.8.3
-  resolution: "@protobuf-ts/grpcweb-transport@npm:2.8.3"
+  version: 2.9.0
+  resolution: "@protobuf-ts/grpcweb-transport@npm:2.9.0"
   dependencies:
-    "@protobuf-ts/runtime": ^2.8.3
-    "@protobuf-ts/runtime-rpc": ^2.8.3
-  checksum: 22b748e6e4f218bc86023bd9a180279ed7fbccc1169c93ab382a94b22868cbfc823eecb84e38213930206f2e78eb2913d4b7e2fabc479388496db7f00112c602
+    "@protobuf-ts/runtime": ^2.9.0
+    "@protobuf-ts/runtime-rpc": ^2.9.0
+  checksum: e9a8efee515f01a21f838f9894b7cd55cdfcd05ee13c526af2aeb5f4d9abfec7a3f275292a84e9277b91721d21c85bcbf97368d3cb7e8728d4ca5755c8e11438
   languageName: node
   linkType: hard
 
-"@protobuf-ts/runtime-rpc@npm:^2.8.2, @protobuf-ts/runtime-rpc@npm:^2.8.3":
-  version: 2.8.3
-  resolution: "@protobuf-ts/runtime-rpc@npm:2.8.3"
+"@protobuf-ts/runtime-rpc@npm:^2.8.2, @protobuf-ts/runtime-rpc@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "@protobuf-ts/runtime-rpc@npm:2.9.0"
   dependencies:
-    "@protobuf-ts/runtime": ^2.8.3
-  checksum: 9b6124abde33669ba87f15f921d6fcc60d09cfd2ffcbdda257e791edbd5be0c66f682ac207843f5841ba829354ec86664c627a4c2cdce3525f4cf9e3db8fdbdf
+    "@protobuf-ts/runtime": ^2.9.0
+  checksum: dfcd538a8b7b6d97714214dae169b5a878b744285aeeceb90429727bf6b263e6233b928f1f64957d69a8878da5d04fb50e1461767052342d62dbc158a940e407
   languageName: node
   linkType: hard
 
-"@protobuf-ts/runtime@npm:^2.8.3":
-  version: 2.8.3
-  resolution: "@protobuf-ts/runtime@npm:2.8.3"
-  checksum: b5237c5ec4b05f407a8afb51e066a5e27d03da55763e9c83a0d0d32433d95d0b8be0cdf5bcafb5616250c382299dc7c9f9b8a4334813e2cb4615e27a971daada
+"@protobuf-ts/runtime@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "@protobuf-ts/runtime@npm:2.9.0"
+  checksum: 62b2eafd0c8941734336f552f89898d224745550ad5eb8166e4bf28db75a1acc2b2e6f9c0b4d0db66bd6efab22fa987fa49c9435d0502cf8aa49f1dce5b35bd9
   languageName: node
   linkType: hard
 
@@ -2659,12 +2659,12 @@ __metadata:
   linkType: hard
 
 "@scure/bip39@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@scure/bip39@npm:1.1.0"
+  version: 1.2.0
+  resolution: "@scure/bip39@npm:1.2.0"
   dependencies:
-    "@noble/hashes": ~1.1.1
+    "@noble/hashes": ~1.3.0
     "@scure/base": ~1.1.0
-  checksum: c4361406f092a45e511dc572c89f497af6665ad81cb3fd7bf78e6772f357f7ae885e129ef0b985cb3496a460b4811318f77bc61634d9b0a8446079a801b6003c
+  checksum: 980d761f53e63de04a9e4db840eb13bfb1bd1b664ecb04a71824c12c190f4972fd84146f3ed89b2a8e4c6bd2c17c15f8b592b7ac029e903323b0f9e2dae6916b
   languageName: node
   linkType: hard
 
@@ -3384,9 +3384,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0":
-  version: 18.15.11
-  resolution: "@types/node@npm:18.15.11"
-  checksum: 977b4ad04708897ff0eb049ecf82246d210939c82461922d20f7d2dcfd81bbc661582ba3af28869210f7e8b1934529dcd46bff7d448551400f9d48b9d3bddec3
+  version: 20.1.3
+  resolution: "@types/node@npm:20.1.3"
+  checksum: abdb593f662a079715b4e9df0c706822e49814dd641fa5a6226ab73fb931cbfc9cfd5df92e09c13dbc90dbc8fce680d29cb735b88899d661481d93e09a8df2be
   languageName: node
   linkType: hard
 
@@ -5453,6 +5453,17 @@ __metadata:
     strip-ansi: ^6.0.0
     wrap-ansi: ^7.0.0
   checksum: ce2e8f578a4813806788ac399b9e866297740eecd4ad1823c27fd344d78b22c5f8597d548adbcc46f0573e43e21e751f39446c5a5e804a12aace402b7a315d7f
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.1
+    wrap-ansi: ^7.0.0
+  checksum: 79648b3b0045f2e285b76fb2e24e207c6db44323581e421c3acbd0e86454cba1b37aea976ab50195a49e7384b871e6dfb2247ad7dec53c02454ac6497394cb56
   languageName: node
   linkType: hard
 
@@ -9974,9 +9985,9 @@ __metadata:
   linkType: hard
 
 "long@npm:^5.0.0":
-  version: 5.2.1
-  resolution: "long@npm:5.2.1"
-  checksum: 9264da12d1b7df67e5aa6da4498144293caf1ad12e7f092efe4e9a2d32c53f0bbf7334f7cef997080a2a3af061142558ab366efa71698d98b1cdb883477445a7
+  version: 5.2.3
+  resolution: "long@npm:5.2.3"
+  checksum: 885ede7c3de4facccbd2cacc6168bae3a02c3e836159ea4252c87b6e34d40af819824b2d4edce330bfb5c4d6e8ce3ec5864bdcf9473fa1f53a4f8225860e5897
   languageName: node
   linkType: hard
 
@@ -15273,6 +15284,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
+  languageName: node
+  linkType: hard
+
 "yargs@npm:^13.2.4":
   version: 13.3.2
   resolution: "yargs@npm:13.3.2"
@@ -15303,6 +15321,21 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: ^8.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.1.1
+  checksum: 73b572e863aa4a8cbef323dd911d79d193b772defd5a51aab0aca2d446655216f5002c42c5306033968193bdbf892a7a4c110b0d77954a7fdf563e653967b56a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,7 +1654,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/react-components@workspace:packages/react-components"
   dependencies:
-    "@concordium/wallet-connectors": ^0.2.1
+    "@concordium/wallet-connectors": ^0.2.3
     "@tsconfig/recommended": ^1.0.1
     "@types/node": ^18.11.17
     "@types/react": ^18
@@ -1672,7 +1672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/wallet-connectors@^0.2.1, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
+"@concordium/wallet-connectors@^0.2.3, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
   version: 0.0.0-use.local
   resolution: "@concordium/wallet-connectors@workspace:packages/wallet-connectors"
   dependencies:


### PR DESCRIPTION
## Purpose

Add support for using the gRPC client for API version 2 and match BW deprecation of JSON-RPC.

## Changes

Deprecated the existing method `getJsonRpcClient` on `WalletConnection` in `wallet-connectors` in favor of the new hook `useGrpcClient` in `react-components`.

Standard network configurations have been added to `wallet-connectors` for testnet and mainnet as constants that were extracted from the sample dApps. A field holding gRPC Web client options was added to `Network` with standard URLs `https://grpc.testnet.concordium.com` and `https://grpc.mainnet.concordium.software` for testnet and mainnet, respectively.

Resolves [CBW-947](https://concordium.atlassian.net/browse/CBW-947).

[CBW-947]: https://concordium.atlassian.net/browse/CBW-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ