### PR TITLE
CI: Add workflow for testing libs and document release workflow

### DIFF
--- a/.github/workflows/build+release.yml
+++ b/.github/workflows/build+release.yml
@@ -1,4 +1,23 @@
-name: Build and upload release
+# Release/publish workflow to run on all pushed commits.
+
+# The commit to be released is selected by ref using the input 'tag_override' and defaults to the ref that triggered the workflow.
+# The ref must be an annotated tag with a specific format and a message consisting of the release notes.
+# The format of the tag must match the pattern '<package>/<version>', where '@concordium/<package>' is a workspace within
+# the project (located at './packages/<package>') and '<version>' must start with the value of the "version" field of
+# the 'package.json' file for that package.
+#
+# The workflow builds all packages in the project but publishes only '<package>'.
+# The release is uploaded as a GitHub release with the release notes fetched from the annotated tag
+# followed by the changelog entries for the version.
+# The release includes the build artifact assembled using 'npm pack'.
+#
+# The workflow fails without uploading if the ref doesn't satisfy some of the requirements above or if any package fails to build.
+#
+# In addition to uploading a GitHub release, the workflow is intended to also publish the package to NPM registry in the future.
+# For now, the process of publishing is to download the pack file from the GitHub release to a box that is logged into the organization
+# (using 'npm login') and then publish it using the command 'npm publish <pack-file>'.
+
+name: Build and publish release
 
 on:
     workflow_dispatch: # trigger manually

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -14,7 +14,7 @@ env:
     node_version: "16.x"
 
 jobs:
-    build-and-upload-release:
+    build-and-test:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout project

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -31,4 +31,4 @@ jobs:
             - name: Build all libraries and samples
               run: yarn workspaces foreach -tv run build
             - name: Run tests
-              run: yarn workspaces foreach -tv run test
+              run: yarn workspaces foreach -tv run test --passWithNoTests

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -9,6 +9,8 @@ name: Build and test
 
 on:
     push:
+        branches: main
+    pull_request:
 
 env:
     node_version: "16.x"

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -1,0 +1,25 @@
+name: Build and test
+
+on:
+    push:
+
+env:
+    node_version: "16.x"
+
+jobs:
+    build-and-upload-release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout project
+              uses: actions/checkout@v3
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "${{env.node_version}}"
+                  cache: yarn
+            - name: Run yarn install
+              run: yarn install --immutable
+            - name: Build all libraries
+              run: yarn build
+            - name: Run tests
+              run: yarn test

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -1,3 +1,10 @@
+# Verification workflow to run on all pushed commits.
+# Performs the following checks:
+# - 'yarn install' performs no changes to 'yarn.lock'.
+# - Check formatting in all workspaces.
+# - Build all workspaces.
+# - Run all tests.
+
 name: Build and test
 
 on:
@@ -19,7 +26,9 @@ jobs:
                   cache: yarn
             - name: Run yarn install
               run: yarn install --immutable
-            - name: Build all libraries
-              run: yarn build
+            - name: Check formatting
+              run: yarn workspaces foreach -tv run prettier --check .
+            - name: Build all libraries and samples
+              run: yarn workspaces foreach -tv run build
             - name: Run tests
-              run: yarn test
+              run: yarn workspaces foreach -tv run test

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -13,7 +13,7 @@ on:
     pull_request:
 
 env:
-    node_version: "16.x"
+    node_version: '16.x'
 
 jobs:
     build-and-test:
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: "${{env.node_version}}"
+                  node-version: '${{env.node_version}}'
                   cache: yarn
             - name: Run yarn install
               run: yarn install --immutable

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "fmt": "yarn workspaces foreach -v run prettier --write .",
         "build": "yarn workspaces foreach -tv --no-private run build",
+        "test": "yarn workspaces foreach -tv --no-private run test",
         "postinstall": "husky install",
         "prepack": "pinst --disable",
         "postpack": "pinst --enable"


### PR DESCRIPTION
## Purpose

Avoid bad/incomplete changes to get merged into main or detected when they are.

## Changes

Add CI workflow for checking formatting and running build and tests in all workspaces. The workflow is automatically triggered on updates to PRs or merges/direct pushes to `main`.

The project doesn't actually contain any tests atm., but once added, this ensures that they get checked.