### PR TITLE
CI: Let release script publish to NPM registry

### DIFF
--- a/.github/workflows/build+release.yml
+++ b/.github/workflows/build+release.yml
@@ -13,9 +13,9 @@
 #
 # The workflow fails without uploading if the ref doesn't satisfy some of the requirements above or if any package fails to build.
 #
-# In addition to uploading a GitHub release, the workflow is intended to also publish the package to NPM registry in the future.
-# For now, the process of publishing is to download the pack file from the GitHub release to a box that is logged into the organization
-# (using 'npm login') and then publish it using the command 'npm publish <pack-file>'.
+# In addition to uploading a GitHub release, the workflow also publish the package to the npmjs registry.
+# If for whatever reason this step stops working, the process of publishing is to download the pack file from the GitHub release
+# to a box that is logged into the organization (using 'npm login') and then publish it using the command 'npm publish <pack-file>'.
 
 name: Build and publish release
 

--- a/.github/workflows/build+release.yml
+++ b/.github/workflows/build+release.yml
@@ -74,7 +74,9 @@ jobs:
             - name: Archive target library
               run: npm pack --workspace="${{steps.package.outputs.workspace}}"
             - name: Publish library to npm [dry run]
-              run: npm publish --dry-run "${{steps.release.outputs.npm-pack-file}}"
+              run: npm publish "${{steps.release.outputs.npm-pack-file}}"
+              env:
+                NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
             - name: Extract changelog entries
               uses: concordium/github-action-changelog-extract@v1
               id: changelog

--- a/.github/workflows/build+release.yml
+++ b/.github/workflows/build+release.yml
@@ -85,6 +85,7 @@ jobs:
               with:
                   node-version: '${{env.node_version}}'
                   cache: yarn
+                  registry-url: 'https://registry.npmjs.org'
             - name: Run yarn install
               run: yarn install --immutable
             # TODO Find a way to force target lib to not build against local build of dependent lib, but always against published build.

--- a/.github/workflows/build+release.yml
+++ b/.github/workflows/build+release.yml
@@ -92,7 +92,7 @@ jobs:
               run: yarn build
             - name: Archive target library
               run: npm pack --workspace="${{steps.package.outputs.workspace}}"
-            - name: Publish library to npm [dry run]
+            - name: Publish library to npm
               run: npm publish "${{steps.release.outputs.npm-pack-file}}"
               env:
                 NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build+release.yml
+++ b/.github/workflows/build+release.yml
@@ -13,9 +13,9 @@
 #
 # The workflow fails without uploading if the ref doesn't satisfy some of the requirements above or if any package fails to build.
 #
-# In addition to uploading a GitHub release, the workflow also publish the package to the npmjs registry.
-# If for whatever reason this step stops working, the process of publishing is to download the pack file from the GitHub release
-# to a box that is logged into the organization (using 'npm login') and then publish it using the command 'npm publish <pack-file>'.
+# In addition to uploading a GitHub release, the workflow also publishes the package to the npmjs registry.
+# If, for whatever reason, this step stops working, download the pack file from the GitHub release to a box
+# that is logged into the organization (using 'npm login') and publish it manually using the command 'npm publish <pack-file>'.
 
 name: Build and publish release
 
@@ -96,7 +96,7 @@ jobs:
             - name: Publish library to npm
               run: npm publish "${{steps.release.outputs.npm-pack-file}}"
               env:
-                NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                NODE_AUTH_TOKEN: '${{secrets.NPM_TOKEN}}'
             - name: Extract changelog entries
               uses: concordium/github-action-changelog-extract@v1
               id: changelog

--- a/.github/workflows/build+release.yml
+++ b/.github/workflows/build+release.yml
@@ -1,4 +1,4 @@
-# Release/publish workflow to run on all pushed commits.
+# Workflow for building and publishing a release of one of the libraries based on an annotated tag.
 
 # The commit to be released is selected by ref using the input 'tag_override' and defaults to the ref that triggered the workflow.
 # The ref must be an annotated tag with a specific format and a message consisting of the release notes.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,28 @@ yarn build
 ```
 
 to build all the libraries into the `dist` subfolder of their respective paths.
+
+## Release
+
+The libraries are released individually using the GitHub Actions workflow
+[`Build and publish release`](./.github/workflows/build+release.yml).
+The procedure is as follows:
+
+1. Add an annotated tag with the format `<package>/<version>` for the commit to build from,
+   where `<package>` is `wallet-connectors` or `react-components` and `<version>` is the version to release.
+   The version must match the version given in `package.json` of the package followed by a build version.
+   Example:
+   ```
+   git checkout <commit-to-release>
+   git tag -a wallet-connectors/1.2.3-0
+   ```
+2. Provide an overview of the changes in the release as the message of the annotated tag.
+   The release notes of the GitHub release will consist of this message followed by the items corresponding to the version
+   extracted from the library's `CHANGELOG.md`.
+3. Run the GitHub Actions workflow
+   [`Build and publish release`](https://github.com/Concordium/concordium-dapp-libraries/actions/workflows/build+release.yml)
+   using the "Run Workflow" button.
+   Keep `main` as the selected option of "Use workflow from" and provide the annotated tag as the value of "Tag".
+   Hit "Run workflow" to start the workflow.
+4. If the tag satisfies all the requirements, the workflow will build the package and publish it as both a GitHub release and to the npm registry.
+   Note that the procedure has to be done once for each package to release.

--- a/README.md
+++ b/README.md
@@ -43,21 +43,28 @@ The libraries are released individually using the GitHub Actions workflow
 [`Build and publish release`](./.github/workflows/build+release.yml).
 The procedure is as follows:
 
-1. Add an annotated tag with the format `<package>/<version>` for the commit to build from,
+1. Add an annotated tag for the commit to build from.
+   The name of the tag name must follow the format `<package>/<version>`,
    where `<package>` is `wallet-connectors` or `react-components` and `<version>` is the version to release.
    The version must match the version given in `package.json` of the package followed by a build version.
-   Example:
+
+   Example: Release `@concordium/wallet-connectors` version 1.2.3 from commit `<ref>`:
    ```
-   git checkout <commit-to-release>
+   git checkout <ref>
    git tag -a wallet-connectors/1.2.3-0
    ```
 2. Provide an overview of the changes in the release as the message of the annotated tag.
-   The release notes of the GitHub release will consist of this message followed by the items corresponding to the version
+   The release notes of the GitHub release is constructed from this message followed by the items corresponding to the version
    extracted from the library's `CHANGELOG.md`.
 3. Run the GitHub Actions workflow
    [`Build and publish release`](https://github.com/Concordium/concordium-dapp-libraries/actions/workflows/build+release.yml)
    using the "Run Workflow" button.
-   Keep `main` as the selected option of "Use workflow from" and provide the annotated tag as the value of "Tag".
+   Keep `main` as the selected option of "Use workflow from" and provide the name of the tag created above as the value of "Tag".
    Hit "Run workflow" to start the workflow.
-4. If the tag satisfies all the requirements, the workflow will build the package and publish it as both a GitHub release and to the npm registry.
-   Note that the procedure has to be done once for each package to release.
+4. If the tag satisfies all the requirements, the workflow will build the package and publish it as a GitHub release
+   as well as to the npm registry.
+   Note that the procedure has to be performed once for each package to release.
+
+The npm package is published using the API key stored in the repository secret `NPM_TOKEN`,
+which belongs to the npm user `concordium-ci`.
+The current key expires 2024-06-03.


### PR DESCRIPTION
Make the `build+release` workflow actually publish the built packages to npmjs, not just as a dry-run.

Based on https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry.

The API key has been added as a repository secret.