### PR TITLE
contractupdate: Use gRPC client

### DIFF
--- a/samples/contractupdate/src/App.tsx
+++ b/samples/contractupdate/src/App.tsx
@@ -18,37 +18,34 @@ export function App({ network, rpc, connection, connectedAccount }: Props) {
     const contract = useContractSelector(rpc, input);
     return (
         <>
-            {connection && (
+            <Form.Group as={Row} className="mb-3" controlId="contract">
+                <Form.Label column sm={3}>
+                    Contract index:
+                </Form.Label>
+                <Col sm={9}>
+                    <Form.Control
+                        type="text"
+                        placeholder="Address (index)"
+                        value={input}
+                        onChange={(e) => setInput(e.currentTarget.value)}
+                        isInvalid={Boolean(contract.error)}
+                        autoFocus
+                    />
+                    <Form.Control.Feedback type="invalid">{contract.error}</Form.Control.Feedback>
+                </Col>
+            </Form.Group>
+            {contract.isLoading && <Spinner animation="border" />}
+            {contract.selected && rpc && (
                 <>
-                    <Form.Group as={Row} className="mb-3" controlId="contract">
-                        <Form.Label column sm={3}>
-                            Contract index:
-                        </Form.Label>
-                        <Col sm={9}>
-                            <Form.Control
-                                type="text"
-                                placeholder="Address (index)"
-                                value={input}
-                                onChange={(e) => setInput(e.currentTarget.value)}
-                                isInvalid={Boolean(contract.error)}
-                                autoFocus
-                            />
-                            <Form.Control.Feedback type="invalid">{contract.error}</Form.Control.Feedback>
-                        </Col>
-                    </Form.Group>
-                    {contract.isLoading && <Spinner animation="border" />}
-                    {contract.selected && (
-                        <>
-                            <ContractDetails contract={contract.selected} />
-                            <hr />
-                            <ContractInvoker
-                                network={network}
-                                connection={connection}
-                                connectedAccount={connectedAccount}
-                                contract={contract.selected}
-                            />
-                        </>
-                    )}
+                    <ContractDetails contract={contract.selected} />
+                    <hr />
+                    <ContractInvoker
+                        rpc={rpc}
+                        network={network}
+                        connection={connection}
+                        connectedAccount={connectedAccount}
+                        contract={contract.selected}
+                    />
                 </>
             )}
         </>

--- a/samples/contractupdate/src/ContractInvoker.tsx
+++ b/samples/contractupdate/src/ContractInvoker.tsx
@@ -9,7 +9,13 @@ import {
     moduleSchemaFromBase64,
     typeSchemaFromBase64,
 } from '@concordium/react-components';
-import { AccountAddress, AccountTransactionType, CcdAmount, SchemaVersion } from '@concordium/web-sdk';
+import {
+    AccountAddress,
+    AccountTransactionType,
+    CcdAmount,
+    ConcordiumGRPCClient,
+    SchemaVersion,
+} from '@concordium/web-sdk';
 import { useContractSchemaRpc } from './useContractSchemaRpc';
 import { errorString } from './util';
 
@@ -19,8 +25,9 @@ interface ContractParamEntry {
 }
 
 interface ContractInvokerProps {
+    rpc: ConcordiumGRPCClient,
     network: Network;
-    connection: WalletConnection;
+    connection: WalletConnection | undefined;
     connectedAccount: string | undefined;
     contract: Info;
 }
@@ -89,7 +96,7 @@ function ccdScanUrl(network: Network, txHash: string | undefined) {
     return `${network.ccdScanBaseUrl}/?dcount=1&dentity=transaction&dhash=${txHash}`;
 }
 
-export function ContractInvoker({ network, connection, connectedAccount, contract }: ContractInvokerProps) {
+export function ContractInvoker({ rpc, network, connection, connectedAccount, contract }: ContractInvokerProps) {
     const [selectedMethodIndex, setSelectedMethodIndex] = useState(0);
     const [schemaInput, setSchemaInput] = useState('');
     // Reset selected method and schema input on contract change.
@@ -98,8 +105,7 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
         setSchemaInput('');
     }, [contract]);
 
-    const schemaRpcResult = useContractSchemaRpc(connection, contract);
-
+    const schemaRpcResult = useContractSchemaRpc(rpc, contract);
     const [schemaTypeInput, setSchemaTypeInput] = useState(DEFAULT_SCHEMA_TYPE);
 
     const [contractParams, setContractParams] = useState<Array<ContractParamEntry>>([]);
@@ -143,7 +149,7 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
     const [isAwaitingApproval, setIsAwaitingApproval] = useState(false);
     const [submittedTxHash, setSubmittedTxHash] = useState<Result<string, string>>();
     const submit = useCallback(() => {
-        if (connectedAccount) {
+        if (connection && connectedAccount) {
             setIsAwaitingApproval(true);
             inputResult
                 .asyncAndThen(([parameters, { schema }, amount]) =>
@@ -304,10 +310,17 @@ export function ContractInvoker({ network, connection, connectedAccount, contrac
                 </Form.Group>
                 <Row>
                     <Col>
-                        <Button onClick={submit} disabled={isAwaitingApproval || inputResult.isErr()}>
-                            {isAwaitingApproval && 'Waiting for approval...'}
-                            {!isAwaitingApproval && 'Submit'}
-                        </Button>
+                        {!connection && (
+                            <Button disabled={true}>
+                                Connect wallet to submit
+                            </Button>
+                        )}
+                        {connection && (
+                            <Button onClick={submit} disabled={isAwaitingApproval || inputResult.isErr()}>
+                                {isAwaitingApproval && 'Waiting for approval...'}
+                                {!isAwaitingApproval && 'Submit'}
+                            </Button>
+                        )}
                     </Col>
                 </Row>
                 <Row>

--- a/samples/contractupdate/src/ContractInvoker.tsx
+++ b/samples/contractupdate/src/ContractInvoker.tsx
@@ -25,7 +25,7 @@ interface ContractParamEntry {
 }
 
 interface ContractInvokerProps {
-    rpc: ConcordiumGRPCClient,
+    rpc: ConcordiumGRPCClient;
     network: Network;
     connection: WalletConnection | undefined;
     connectedAccount: string | undefined;
@@ -310,11 +310,7 @@ export function ContractInvoker({ rpc, network, connection, connectedAccount, co
                 </Form.Group>
                 <Row>
                     <Col>
-                        {!connection && (
-                            <Button disabled={true}>
-                                Connect wallet to submit
-                            </Button>
-                        )}
+                        {!connection && <Button disabled={true}>Connect wallet to submit</Button>}
                         {connection && (
                             <Button onClick={submit} disabled={isAwaitingApproval || inputResult.isErr()}>
                                 {isAwaitingApproval && 'Waiting for approval...'}

--- a/samples/contractupdate/src/useContractSchemaRpc.ts
+++ b/samples/contractupdate/src/useContractSchemaRpc.ts
@@ -38,10 +38,7 @@ function findSchema(m: WebAssembly.Module): Result<SchemaRpcResult | undefined, 
 export function useContractSchemaRpc(rpc: ConcordiumGRPCClient, contract: Info) {
     const [result, setResult] = useState<Result<SchemaRpcResult | undefined, string>>();
     useEffect(() => {
-        ResultAsync.fromPromise(
-            rpc.getModuleSource(new ModuleReference(contract.moduleRef)),
-            errorString
-        )
+        ResultAsync.fromPromise(rpc.getModuleSource(new ModuleReference(contract.moduleRef)), errorString)
             .andThen((r) => {
                 if (!r) {
                     return err('module source is empty');

--- a/samples/contractupdate/src/useContractSchemaRpc.ts
+++ b/samples/contractupdate/src/useContractSchemaRpc.ts
@@ -1,8 +1,8 @@
 import { Buffer } from 'buffer/';
 import { Result, ResultAsync, err, ok } from 'neverthrow';
 import { useEffect, useState } from 'react';
-import { Info, Schema, WalletConnection, moduleSchema, withJsonRpcClient } from '@concordium/react-components';
-import { ModuleReference, SchemaVersion } from '@concordium/web-sdk';
+import { Info, Schema, moduleSchema } from '@concordium/react-components';
+import { ConcordiumGRPCClient, ModuleReference, SchemaVersion } from '@concordium/web-sdk';
 import { errorString } from './util';
 
 export interface SchemaRpcResult {
@@ -35,25 +35,21 @@ function findSchema(m: WebAssembly.Module): Result<SchemaRpcResult | undefined, 
     return ok({ sectionName, schema: moduleSchema(Buffer.from(contents[0]), schemaVersion) });
 }
 
-export function useContractSchemaRpc(connection: WalletConnection, contract: Info) {
+export function useContractSchemaRpc(rpc: ConcordiumGRPCClient, contract: Info) {
     const [result, setResult] = useState<Result<SchemaRpcResult | undefined, string>>();
     useEffect(() => {
         ResultAsync.fromPromise(
-            withJsonRpcClient(connection, (rpc) => rpc.getModuleSource(new ModuleReference(contract.moduleRef))),
+            rpc.getModuleSource(new ModuleReference(contract.moduleRef)),
             errorString
         )
             .andThen((r) => {
                 if (!r) {
                     return err('module source is empty');
                 }
-                // Skip 8-byte header (module version and length).
-                if (r.length < 8) {
-                    return err(`module source is ${r.length} bytes which is not enough to fit an 8-byte header`);
-                }
-                return ResultAsync.fromPromise(WebAssembly.compile(r.slice(8)), errorString);
+                return ResultAsync.fromPromise(WebAssembly.compile(r), errorString);
             })
             .andThen(findSchema)
             .then(setResult);
-    }, [contract, connection]);
+    }, [contract, rpc]);
     return result;
 }


### PR DESCRIPTION
The JSON-RPC client is deprecated and replaced with the gRPC client. When merging that change, only one of the RPC usages in the sample dApp were migrated. This migrates the other use (to use the same client). As the new client is connection-independent, the query screen now appears immediately after the application has loaded.

A significant change is that the 'getModuleSource' method of gRPC client returns the module source without the module version and length (and actually another byte before that) prefix.