### PR TITLE
wallet-connectors: Fix schema object serialization for WalletConnect

### DIFF
--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Schema object serialization in `signAndSendTransaction` for WalletConnect requests.
+-   Schema object format conversion in `signAndSendTransaction` for WalletConnect requests.
 
 ## [0.3.1] - 2023-06-04
 

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Schema object serialization in `signAndSendTransaction` for WalletConnect requests.
+
 ## [0.3.1] - 2023-06-04
 
 ### Added

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -124,7 +124,7 @@ function serializeUpdateContractMessage(
  * Convert schema into the object format expected by the Mobile crypto library.
  * @param schema The schema object.
  */
-function serializeSchema(schema: Schema | undefined) {
+function convertSchemaFormat(schema: Schema | undefined) {
     if (!schema) {
         return null;
     }
@@ -253,7 +253,7 @@ export class WalletConnectConnection implements WalletConnection {
             type: AccountTransactionType[type],
             sender: accountAddress,
             payload: accountTransactionPayloadToJson(serializePayloadParameters(type, payload, typedParams)),
-            schema: serializeSchema(typedParams?.schema),
+            schema: convertSchemaFormat(typedParams?.schema),
         };
         try {
             const { hash } = (await this.connector.client.request({

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -16,6 +16,7 @@ import SignClient from '@walletconnect/sign-client';
 import { ISignClient, SessionTypes, SignClientTypes } from '@walletconnect/types';
 import {
     Network,
+    Schema,
     SignableMessage,
     TypedSmartContractParameters,
     WalletConnection,
@@ -114,6 +115,31 @@ function serializeUpdateContractMessage(
             );
         case 'TypeSchema':
             return serializeTypeValue(parameters, schema.value);
+        default:
+            throw new UnreachableCaseError('schema', schema);
+    }
+}
+
+/**
+ * Convert schema into the object format expected by the Mobile crypto library.
+ * @param schema The schema object.
+ */
+function serializeSchema(schema: Schema | undefined) {
+    if (!schema) {
+        return null;
+    }
+    switch (schema.type) {
+        case 'ModuleSchema':
+            return {
+                type: 'module',
+                value: schema.value.toString('base64'),
+                version: schema.version,
+            };
+        case 'TypeSchema':
+            return {
+                type: 'parameter',
+                value: schema.value.toString('base64'),
+            };
         default:
             throw new UnreachableCaseError('schema', schema);
     }
@@ -227,7 +253,7 @@ export class WalletConnectConnection implements WalletConnection {
             type: AccountTransactionType[type],
             sender: accountAddress,
             payload: accountTransactionPayloadToJson(serializePayloadParameters(type, payload, typedParams)),
-            schema: typedParams?.schema,
+            schema: serializeSchema(typedParams?.schema),
         };
         try {
             const { hash } = (await this.connector.client.request({


### PR DESCRIPTION
## Purpose

Ensure that schema objects are sent in the format expected by the Mobile Wallets.

## Changes

Translate the `Schema` object into one that JSON encodes as expected by the Mobile Wallet Crypto library.

Currently the schema objects are sent directly which means that the `type` field has unexpected values and the value is converted to a `Buffer` (format `{type: "Buffer", data: [<bytes>]}`) instead of a base64 encoded string.

The Android wallet accepts the current payload but silently fails to decode the parameters and just prints "No parameters". I've verified that it prints the correct payload after this change. The iOS wallet's WalletConnect implementation is going to accept both formats.