### PR TITLE
Address error handling issues

### DIFF
--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -269,6 +269,7 @@ export class WalletConnectConnection implements WalletConnection {
             if (isSignAndSendTransactionError(e) && e.code === 500) {
                 throw new Error('transaction rejected in wallet');
             }
+            // TODO Re-throw non-Error as a proper Error.
             throw e;
         }
     }
@@ -277,6 +278,7 @@ export class WalletConnectConnection implements WalletConnection {
         switch (msg.type) {
             case 'StringMessage': {
                 const params = { message: msg.value };
+                // TODO Catch thrown non-Error and rethrow it as a proper Error.
                 const signature = await this.connector.client.request({
                     topic: this.session.topic,
                     request: {

--- a/samples/contractupdate/src/ContractInvoker.tsx
+++ b/samples/contractupdate/src/ContractInvoker.tsx
@@ -148,6 +148,13 @@ export function ContractInvoker({ rpc, network, connection, connectedAccount, co
 
     const [isAwaitingApproval, setIsAwaitingApproval] = useState(false);
     const [submittedTxHash, setSubmittedTxHash] = useState<Result<string, string>>();
+
+    // Reset 'isAwaitingApproval' and 'submittedTxHash' whenever connection changes.
+    useEffect(() => {
+        setSubmittedTxHash(undefined);
+        setIsAwaitingApproval(false);
+    }, [connection]);
+
     const submit = useCallback(() => {
         if (connection && connectedAccount) {
             setIsAwaitingApproval(true);

--- a/samples/contractupdate/src/util.ts
+++ b/samples/contractupdate/src/util.ts
@@ -3,5 +3,8 @@ export function setErrorString(setError: (err: string) => void) {
 }
 
 export function errorString(err: any): string {
-    return (err as Error).message || (err as string);
+    if (err instanceof Error) {
+        return err.message;
+    }
+    return err.toString();
 }

--- a/samples/sign-message/src/App.tsx
+++ b/samples/sign-message/src/App.tsx
@@ -1,5 +1,5 @@
 import { ResultAsync, err, ok } from 'neverthrow';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Col, Container, Form, InputGroup, Row, Spinner } from 'react-bootstrap';
 import {
     TESTNET,
@@ -64,9 +64,15 @@ function Main(props: WalletConnectionProps) {
         }
     }, [messageInput, schemaResult]);
 
-    const [signature, setSignature] = useState<AccountTransactionSignature>('');
-    const [error, setError] = useState('');
+    const [signature, setSignature] = useState<AccountTransactionSignature>();
+    const [error, setError] = useState<any>(); // WC throws objects; giving up on using strings for now
     const [isWaiting, setIsWaiting] = useState(false);
+
+    // Reset 'error' and 'isWaiting' whenever connection changes.
+    useEffect(() => {
+        setError(undefined);
+        setIsWaiting(false);
+    }, [connection]);
 
     const handleMessageInput = useCallback((e: any) => setMessageInput(e.target.value), []);
     const handleSchemaInput = useCallback((e: any) => setSchemaInput(e.target.value), []);
@@ -74,9 +80,9 @@ function Main(props: WalletConnectionProps) {
         if (connection && account && messageResult) {
             messageResult
                 .asyncAndThen((msg) => {
-                    setError('');
+                    setError(undefined);
                     setIsWaiting(true);
-                    return ResultAsync.fromPromise(connection.signMessage(account, msg), errorString);
+                    return ResultAsync.fromPromise(connection.signMessage(account, msg), (e) => e);
                 })
                 .match(setSignature, setError)
                 .finally(() => setIsWaiting(false));
@@ -183,12 +189,14 @@ function Main(props: WalletConnectionProps) {
                 </Col>
             </Form.Group>
             <Row>
-                {error && <Alert variant="danger">{error}</Alert>}
+                {error && <Alert variant="danger">{JSON.stringify(error)}</Alert>}
                 {signature && (
                     <>
                         <Col sm={3}>Signature:</Col>
                         <Col sm={9}>
-                            <pre title={`Message: ${messageInput}`}>{JSON.stringify(signature, null, 2)}</pre>
+                            <Alert variant="success" dismissible={true} onClose={() => setSignature(undefined)}>
+                                <pre title={`Message: ${messageInput}`}>{JSON.stringify(signature, null, 2)}</pre>
+                            </Alert>
                         </Col>
                     </>
                 )}

--- a/samples/sign-message/src/util.ts
+++ b/samples/sign-message/src/util.ts
@@ -3,5 +3,8 @@ export function setErrorString(setError: (err: string) => void) {
 }
 
 export function errorString(err: any): string {
-    return (err as Error).message || (err as string);
+    if (err instanceof Error) {
+        return err.message;
+    }
+    return err.toString();
 }


### PR DESCRIPTION
Fixed helper functions in sample dapps for extracting the message of an error - WalletConnect has a habit of throwing errors with empty message, meaning that the error is erroneously type cast to a string.

Furthermore, on errors like "user rejected the request", WalletConnect throws the reject object (which is not an `Error`). This has worked until now because this object just happens to have a `message` field, so the function would "luckily" interpret it as `Error` and extract this message. This changes with this fix and the object will now just render as `[object Object]`. Passing `err` as string like before will fail because we're then trying to render an object which is not allowed in React.

TODO: For the `sign-message` sample, we bit the dust and use `any` for error instead of `string`. We should either see if the problem can be fixed generically or do the same for the `contractupdate` sample.

Partially(?) resolves [CBW-1148](https://concordium.atlassian.net/browse/CBW-1148).

[CBW-1148]: https://concordium.atlassian.net/browse/CBW-1148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ