### PR TITLE
wallet-connectors: Remove deprecated JSON-RPC client integration

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `useContractSelector`: Fix docstring of `rpc` parameter.
+
 ## [0.3.0] - 2023-06-04
 
 ### Added

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -29,7 +29,6 @@ import { Network, WalletConnectionProps, WithWalletConnector } from '@concordium
 const testnet: Network = {
     name: 'testnet',
     genesisHash: '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796',
-    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
     ccdScanBaseUrl: 'https://testnet.ccdscan.io',
 };
 
@@ -139,7 +138,7 @@ export function ContractStuff({ rpc }: Props) {
 ```
 
 Use the hook [`useGrpcClient`](#usegrpcclient) below to obtain a `ConcordiumGRPCClient` instance.
-See [the sample dApp](../../samples/contractupdate/src/App.tsx) for a complete example.
+See [the sample dApp](../../samples/contractupdate/src/Root.tsx) for a complete example.
 
 ### [`useGrpcClient`](./src/useGrpcClient.ts)
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -24,16 +24,10 @@ Initialize the network configuration and wrap the component `MyAppComponent` tha
 in `WithWalletConnector`:
 
 ```typescript jsx
-import { Network, WalletConnectionProps, WithWalletConnector } from '@concordium/react-components';
-
-const testnet: Network = {
-    name: 'testnet',
-    genesisHash: '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796',
-    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
-};
+import { Network, TESTNET, WalletConnectionProps, WithWalletConnector } from '@concordium/react-components';
 
 function MyRootComponent() {
-    return <WithWalletConnector network={network}>{(props) => <MyAppComponent {...props} />}</WithWalletConnector>;
+    return <WithWalletConnector network={TESTNET}>{(props) => <MyAppComponent {...props} />}</WithWalletConnector>;
 }
 
 function MyAppComponent(props: WalletConnectionProps) {

--- a/packages/react-components/src/useContractSelector.ts
+++ b/packages/react-components/src/useContractSelector.ts
@@ -101,7 +101,7 @@ export interface ContractSelector {
 
 /**
  * React hook to look up a smart contract's data and state from its index.
- * @param rpc JSON-RPC proxy client through which to perform the lookup.
+ * @param rpc gRPC client through which to perform the lookup. The JSON-RPC client is supported for backwards compatibility only.
  * @param input The index of the contract to look up.
  * @return The resolved contract and related state.
  */

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `WalletConnect`: Fix schema object format conversion in `signAndSendTransaction` in request payloads.
 -   `WalletConnect`: Use standard string identifiers for transaction type in request payload.
 
+### Removed
+
+-   `WalletConnection`: The deprecated method `getJsonRpcClient()` and related symbols has been removed
+    in favor of the new gRPC client (`ConcordiumGRPCClient`) for the Node API v2.
+    Existing usage is migrated by simply constructing and using this client instead of the one fetched with `connection.getJsonRpcClient`.
+    The `Network` type has a field `grpcOpts` which may be used to construct the client (see its docstring for details).
+    The field is optional, but present on the predefined constants `TESTNET` and `MAINNET`.
+    For users of `@concordium/react-components`, this all wrapped into the hook `useGrpcClient`.
+
 ## [0.3.1] - 2023-06-04
 
 ### Added

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -18,12 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
--   `WalletConnection`: The deprecated method `getJsonRpcClient()` and related symbols has been removed
+-   `WalletConnection`: The deprecated method `getJsonRpcClient()` and related symbols have been removed
     in favor of the new gRPC client (`ConcordiumGRPCClient`) for the Node API v2.
     Existing usage is migrated by simply constructing and using this client instead of the one fetched with `connection.getJsonRpcClient`.
     The `Network` type has a field `grpcOpts` which may be used to construct the client (see its docstring for details).
     The field is optional, but present on the predefined constants `TESTNET` and `MAINNET`.
-    For users of `@concordium/react-components`, this all wrapped into the hook `useGrpcClient`.
+    For users of `@concordium/react-components`, this is all wrapped into the hook `useGrpcClient`.
 
 ## [0.3.1] - 2023-06-04
 

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -26,7 +26,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `WalletConnection`: The deprecated method `getJsonRpcClient()` and related symbols have been removed
     in favor of the new gRPC client (`ConcordiumGRPCClient`) for the Node API v2.
-    Existing usage is migrated by simply constructing and using this client instead of the one fetched with `connection.getJsonRpcClient`.
+    Existing usage is migrated by simply constructing and using this client directly
+    instead of using the one previously fetched with `connection.getJsonRpcClient`.
+    Usage of `withJsonRpcClient`, i.e.,
+    ```typescript
+    if (connection) {
+      const res = await withJsonRpcClient(connection, func);
+      ...
+    }
+    ```
+    may be directly replaced by
+    ```typescript
+    if (grpcClient) {
+      const res = await func(grpcClient);
+      ...
+    }
+    ```
     The `Network` type has a field `grpcOpts` which may be used to construct the client (see its docstring for details).
     The field is optional, but present on the predefined constants `TESTNET` and `MAINNET`.
     For users of `@concordium/react-components`, this is all wrapped into the hook `useGrpcClient`.

--- a/packages/wallet-connectors/src/BrowserWallet.ts
+++ b/packages/wallet-connectors/src/BrowserWallet.ts
@@ -86,10 +86,6 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
         return this.client.getMostRecentlySelectedAccount();
     }
 
-    getJsonRpcClient() {
-        return this.client.getJsonRpcClient();
-    }
-
     /**
      * Returns a gRPC client that is ready to perform requests against some Concordium Node connected to network/chain
      * that the connected account lives on.
@@ -101,7 +97,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
      * that is independent of any connection.
      * See {@link Network.grpcOpts} for more details.
      *
-     * Implementation detail: The method cannot be moved to {@link WalletConnector}
+     * Implementation detail: The method cannot be moved to {@link BrowserWalletConnector}
      * as the Browser Wallet's RPC client doesn't work until a connection has been established.
      *
      * @return The Browser Wallet's internal gRPC client.

--- a/packages/wallet-connectors/src/index.ts
+++ b/packages/wallet-connectors/src/index.ts
@@ -23,7 +23,6 @@ export const TESTNET: Network = {
     grpcOpts: {
         baseUrl: 'https://grpc.testnet.concordium.com:20000',
     },
-    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
     ccdScanBaseUrl: 'https://testnet.ccdscan.io',
 };
 
@@ -36,6 +35,5 @@ export const MAINNET: Network = {
     grpcOpts: {
         baseUrl: 'https://grpc.mainnet.concordium.software:20000',
     },
-    jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software',
     ccdScanBaseUrl: 'https://ccdscan.io',
 };


### PR DESCRIPTION
## Purpose

Remove support for the depreated JSON-RPC client as per [this strategy](https://concordium.atlassian.net/wiki/spaces/EN/pages/1185349645/Remove+V1+GRPC+API).

## Changes

Remove all symbols related to `WalletConnection.getJsonRpcClient`.