### PR TITLE
Update wc modal

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -27,7 +27,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/wallet-connectors": "^0.6.0-alpha.5"
+        "@concordium/wallet-connectors": "^0.6.0-alpha.6"
     },
     "devDependencies": {
         "@tsconfig/recommended": "^1.0.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -27,7 +27,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/wallet-connectors": "^0.6.0-alpha.6"
+        "@concordium/wallet-connectors": "^0.5.1"
     },
     "devDependencies": {
         "@tsconfig/recommended": "^1.0.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -27,7 +27,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/wallet-connectors": "^0.5.1"
+        "@concordium/wallet-connectors": "^0.6.0-alpha.4"
     },
     "devDependencies": {
         "@tsconfig/recommended": "^1.0.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -27,7 +27,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/wallet-connectors": "^0.6.0-alpha.4"
+        "@concordium/wallet-connectors": "^0.6.0-alpha.5"
     },
     "devDependencies": {
         "@tsconfig/recommended": "^1.0.1",

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `cryptoXWallet` and `concordiumWallet` exports, which can be passed to `WalletConnectConnector.connectWithScope` to defined which wallets can be selected for connecting through deeplinking.
+- Added a new method `connectWithScope` to `WalletConnectConnector`, which lets users define the methods and events to request permissions for.
+
+### Changed
+
+- Changed the wallet connect modal dependency from `@walletconnect/qrcode-modal` (which is deprecated) to `@walletconnect/modal`.
+
 ## [0.5.1] - 2024-03-22
 
 ### Fixed

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `cryptoXWallet` and `concordiumWallet` exports, which can be passed to `WalletConnectConnector.connectWithScope` to defined which wallets can be selected for connecting through deeplinking.
-- Added a new method `connectWithScope` to `WalletConnectConnector`, which lets users define the methods and events to request permissions for.
+-   Added `cryptoXWallet` and `concordiumWallet` exports, which can be passed to `WalletConnectConnector.connectWithScope` to defined which wallets can be selected for connecting through deeplinking.
+-   Added a new method `connectWithScope` to `WalletConnectConnector`, which lets users define the methods and events to request permissions for.
 
 ### Changed
 
-- Changed the wallet connect modal dependency from `@walletconnect/qrcode-modal` (which is deprecated) to `@walletconnect/modal`.
+-   Changed the wallet connect modal dependency from `@walletconnect/qrcode-modal` (which is deprecated) to `@walletconnect/modal`.
 
 ## [0.5.1] - 2024-03-22
 

--- a/packages/wallet-connectors/CHANGELOG.md
+++ b/packages/wallet-connectors/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Added `cryptoXWallet` and `concordiumWallet` exports, which can be passed to `WalletConnectConnector.connectWithScope` to defined which wallets can be selected for connecting through deeplinking.
--   Added a new method `connectWithScope` to `WalletConnectConnector`, which lets users define the methods and events to request permissions for.
+-   Added `createWalletConnectModalConfig` to create a configuration the modal shown when connecting to a walletconnect compatible wallet. The value returned can be passed to `WalletConnectConnector.create`.
+-   Added `CRYPTO_X_WALLET_MAINNET` and `CONCORDIUM_WALLET_MAINNET` exports, which can be passed `createWalletConnectModalConfig` for more control over which wallets are shown.
+-   Added option to specify the methods and events to request permission for by walletconnect
 
 ### Changed
 

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -29,7 +29,8 @@
     },
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "^3.0.0",
-        "@walletconnect/qrcode-modal": "^1.8.0",
+        "@walletconnect/modal": "^2.6.2",
+        "@walletconnect/modal-core": "^2.6.2",
         "@walletconnect/sign-client": "^2.1.4"
     },
     "peerDependencies": {

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/wallet-connectors",
-    "version": "0.5.1",
+    "version": "0.6.0-alpha.1",
     "description": "Utility interface for dApps to interact with wallets without depending on the underlying protocol and implementations for Concordium Browser Wallet and Wallet Connect v2.",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/wallet-connectors",
-    "version": "0.6.0-alpha.5",
+    "version": "0.6.0-alpha.6",
     "description": "Utility interface for dApps to interact with wallets without depending on the underlying protocol and implementations for Concordium Browser Wallet and Wallet Connect v2.",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/wallet-connectors",
-    "version": "0.6.0-alpha.3",
+    "version": "0.6.0-alpha.4",
     "description": "Utility interface for dApps to interact with wallets without depending on the underlying protocol and implementations for Concordium Browser Wallet and Wallet Connect v2.",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/wallet-connectors",
-    "version": "0.6.0-alpha.1",
+    "version": "0.6.0-alpha.2",
     "description": "Utility interface for dApps to interact with wallets without depending on the underlying protocol and implementations for Concordium Browser Wallet and Wallet Connect v2.",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/wallet-connectors",
-    "version": "0.6.0-alpha.6",
+    "version": "0.5.1",
     "description": "Utility interface for dApps to interact with wallets without depending on the underlying protocol and implementations for Concordium Browser Wallet and Wallet Connect v2.",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/wallet-connectors",
-    "version": "0.6.0-alpha.2",
+    "version": "0.6.0-alpha.3",
     "description": "Utility interface for dApps to interact with wallets without depending on the underlying protocol and implementations for Concordium Browser Wallet and Wallet Connect v2.",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/wallet-connectors/package.json
+++ b/packages/wallet-connectors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/wallet-connectors",
-    "version": "0.6.0-alpha.4",
+    "version": "0.6.0-alpha.5",
     "description": "Utility interface for dApps to interact with wallets without depending on the underlying protocol and implementations for Concordium Browser Wallet and Wallet Connect v2.",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -138,8 +138,13 @@ async function connect(
                 walletImages,
                 enableExplorer,
             });
+            modal.subscribeModal(({ open }) => {
+                if (!open) {
+                    return cancel();
+                }
+            });
             // Open modal as we're not connecting to an existing pairing.
-            modal.openModal({ uri });
+            await modal.openModal({ uri });
         }
         return await approval();
     } catch (e) {
@@ -552,8 +557,8 @@ export class WalletConnectConnector implements WalletConnector {
             this.network === MAINNET
                 ? [cryptoXWalletMainnet, concordiumWalletMainnet]
                 : this.network === TESTNET
-                    ? [cryptoXWalletTestnet, concordiumWalletTestnet]
-                    : undefined
+                ? [cryptoXWalletTestnet, concordiumWalletTestnet]
+                : undefined
         );
     }
 

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -127,6 +127,7 @@ async function connect(
                 ccd: scope,
             },
         });
+        let response: SessionTypes.Struct | undefined = undefined;
         if (uri) {
             modal = new WalletConnectModal({
                 projectId: CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
@@ -139,14 +140,17 @@ async function connect(
                 enableExplorer,
             });
             modal.subscribeModal(({ open }) => {
-                if (!open) {
-                    return cancel();
+                if (!open && response === undefined) {
+                    cancel();
                 }
             });
+
             // Open modal as we're not connecting to an existing pairing.
             await modal.openModal({ uri });
         }
-        return await approval();
+
+        response = await approval();
+        return response;
     } catch (e) {
         // Ignore falsy errors.
         if (e) {
@@ -154,9 +158,7 @@ async function connect(
         }
         cancel();
     } finally {
-        if (modal !== undefined) {
-            modal.closeModal();
-        }
+        modal?.closeModal();
     }
 }
 

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -26,7 +26,7 @@ import { WalletConnectModal } from '@walletconnect/modal';
 import { MobileWallet } from '@walletconnect/modal-core';
 import SignClient from '@walletconnect/sign-client';
 import { ISignClient, ProposalTypes, SessionTypes, SignClientTypes } from '@walletconnect/types';
-import { CONCORDIUM_WALLET_CONNECT_PROJECT_ID } from '.';
+import { CONCORDIUM_WALLET_CONNECT_PROJECT_ID, MAINNET, TESTNET } from '.';
 import {
     Network,
     Schema,
@@ -57,74 +57,67 @@ export const WalletConnectEvents = {
 export type WalletConnectMethods = typeof WalletConnectMethods[keyof typeof WalletConnectMethods];
 export type WalletConnectEvents = typeof WalletConnectEvents[keyof typeof WalletConnectEvents];
 
-export type WalletConnectMobileWallet =
-    | (MobileWallet & {
-        type: 'customLink';
-        /** Url for an icon to represent the wallet */
-        iconUrl?: string;
-    })
-    | {
-        type: 'explorerId';
-        /** The ID of the wallet in the wallet connect explorer: https://explorer.walletconnect.com/ */
-        value: string;
-    };
+export type WalletConnectMobileWallet = MobileWallet & {
+    /** Url for an icon to represent the wallet */
+    iconUrl?: string;
+};
 
 export const concordiumWalletMainnet: WalletConnectMobileWallet = {
-    type: 'explorerId',
-    value: '7dcb0e5eb1b4fc6e2e0b143201c489ea6c618259f49527527d4a349d1a95ba7b',
+    id: 'ConcordiumMainet',
+    name: 'Concordium Wallet',
+    links: {
+        native: 'concordiumwallet://',
+    },
+    iconUrl:
+        'data:image/webp;base64,UklGRhYJAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4IJAIAADwNwCdASr2APYAPpVKmUejIqEU2wQoNAlE9Ld+Pizr+LYWxZS/TBwLdH/K6W0R2gHuBnEX9aexL/V+gdjmAc/GkRS1VumIAPqd6Bfuvmh9edZ2MnaC/rbgdjbmZmZmZmZmZmZmZmZmZmbIZmTyXTucuirhRPGoAfpkGImqqt/3YwASWFmyG/bP9A39oE5zptUrEnIUEPxyb10xsoP3VDW/cPDwzQGMQhPiKDZ/AXJqcA+3qvnRGhVvjzWO38+JZONxLAMSQln7oacp/aGkTP2CI7U//o7VM3pR4MfkbVoOIXAsGwxsynfeCnsnsY8iVDG7KHQosBfI/xrvmdCADpYcI6NG6Jd3sQqZzsYKzIvGarc+4jFmxKnQEkcpfIZUXieXjQT64aW7tr6Vcy+BC7BftL5EN7fDuWTcCh9xPy5oX3jpEyxNGPwoCbL5y2fMA05eDBANchp+zkopFSdgf5a+S6wS5+W5s8tpOsnBgTnAcI9q0uOTEwCjYSa10TYoZpDhXAih5wReIWxxtS51BN4r9t/r+3XAjLG6TB2p8JLlG360tlj26fz2nHbnIgAAAAKIzOg/60pkb+lEZnQV5b5WU7TjXD68QwAA/vS/wEnP/oMKreuAAAAA/WfNc36Y3zMAAAAA2UAO1xjKXsqNaC5HPIM3yNL+BQ8hQt+wxmwpHDKIc3UouEzyT2lywAHIsI8P/5fMoHSq1d5n+dlw8xmDXlr7XrHtkc25rz2ueWwnEYFwfKQaJgoR1kCrRAABtudYDWl5aMRIA2UlZ0bSWrzjlb/mgBql8N3jfgtVK4F3OI2JOw+DqPiRdEjGz8i0AvNomL3KcwP3L7zRmfp2HGZvCYuhR8jyCtWUBABLg6wCm0TkgxpRApBKS5IClkhuF/UnCWUhq5ntDP+oTZlUVCq4qL6A19+rk9AJ6ox/aGKLuCJE/Sys9oJHTWk7bbd2AK+7W+E1x7PDdFRmteme1WcuX5ZW5gSJ/JSuCWT55kLBz3i0JwvcuNtgWif0fPNSB71IEXXsv7Dl0TvZtfItF+V/MljUPJMvk7qqEnsFFcUeYVgT+253x6Lbg2NB+hEdDDCd3b7FIpqYFKB++q3vmLwxDMQH6e5OROxmjWieruIQ9y9uWvkTpoqCvPL10PIDL8NihCdI4ZS293VL7GW2ld4AZeGtrgczeIWwwRRfJMtiRk9hp5SguQCzK6hE2j0i2+MP05g3l0HsvgYLU+OSaLslG9i+oWCVizfJvxSJx6guQQWEfBWPZBi8Y5TwaPKPCD2f74wtejTEeLdmzFg7KAE6ZqSeQPi+cN3rzS+NdGQA+3F7HQKapSmgVJWJ+HPc7WEv9cEIn2i6NNMunpgLp+ZrFpQDqjyWVplxH2n1+lrMiwOJVTTubzRTMAMSP/kkT3tj9LmfHpF7qI+scitZetxN1QTM8NG5zr8fX/UVU/HolSx2YXqIXV5wi/mCGIU7eXZoGxLSeHULMMKZ7c2UmZaE643Tl5HCaO2Ri5lFYbMkwPqqKL33tLVb2Tycl0nQyzihq1M7aVT6KVIDnxDPrCDjEOUI5zsmvqniV0Qp2bPq8frtn/KrhV3sP/L4E7LMM/jcwr5y6yghSOvBDAfLsjgJf7lfwMayafHmmiP+Zj5lz8mtCt8esQm2i1gQrcoziKfYKmGO8qycD9hkNFi5IBEz2J1VMQNkbnTz0ysgf1WSsrxDkhwSHqNcOZAD22Xy7L2IcwqWTTZRxmhOWlp5OP8JkMI2prkoojZ1JbrPRexFlg+2ZFWeBdgxc5OhGqLoL1mnISRyRfZkdugOnxnIB/SiCxhA51Uw4RaE/mVsMsMxt8jQB9/WGWlQ0LBkaCvsdSIBwsKIge6OPK1rvR6N7L/YU0VmHIsjRvO2SBympDY/yS5V4CETf8+0TfGnIo2J1oLqD3BbuZB25s7yTMLtmESRtLB5HbuGhnRjf4Gi69a0ziESm543hKe3+nQiD/jcjXw8VTLb5oe+jIBOpledmLdHXug0OOcSqjoh4GCDN8cka29NCHpxJNhsO0+CTNcIfGBTnvVG2L6SH4QLgVOLsZryT1lungAz2S6V7Yhk3iGHFi1jBZYKwfyNbs0u0S+uYBEl6hhYoobezYRHLlZx+kMEv09+YgDR/056s6m4VjzRhi32AfkbeJnrfX3UEfCbNOBH8xIExiEeU0M2WNfHD0wbEuG3NVB/sqdSAp+jaTYr0TCP6oYjw7opj7NdNfwekPkuyvK5g1x2ijisTDPVh2+ppc8o6//M/EbOi2BP3L2l15/dm/hi1EC51FSzUmrJUkY+v6E8zoT04p124JMHLamYtii9kiVyIx+YDFlHA+UiXH6OtXFo4+sdwUe7kyfaEnTV/7lwShO+U2fPYeJ8e8wQ1iHSMKOYhWaakW+v7wspz2hqgJ4ZiRE5yHobn90KASZBSoxhSFB2mnQSot3UYqpyzonnlyPHSwQ/tmr+P0k+QFMmhreH0APbWTVrLhWLyWx0iVEMQZqG8deFJnUzafelQ/fQKq72PnHlvjZycEw+A2FbPxtc/lyh3OWzh5gMd9vkqVBMUU4tnXS6GDRdqNtRxtzeKw4BwTtfIxsxFJl9t+njZV3GsS+1TRSb5grO9xX84n96SD+YS/GmK9WTdcRLRcvE+nc9KskXTMjD4X4i4aiJE0tzYdngR4870RCRJVSdsWT3lR8U/6q73Ftl/NMG/JoLK28WyADmuj4wLLxchOBptE+cFjRw7Syp4lZdT2a4dZ8yKL6drDCwAQ5Hd+JMSvTck3HvV7OHnG1HJNhYyBKbTsN7eSzry1JxztqGVOxxS9dt1gv3QL0kb/G3KtbxgNfLxS0orOw2Ck3FA0W73AFKAovPp7n2sr4gFItAPoKQIK6uC6gHlvqjZgj3wrT2dgfgY09Sx8oQ/Cdt6TgAAEVYSUZfAAAASUkqAAgAAAABAGmHBAABAAAAGgAAAAAAAAABAIaSBwAyAAAALAAAAAAAAABBU0NJSQAAADEuNzIuMC0yM0otTkFRQkZIMlE3Tk9OQU80QldBN1pHQ05WTUkuMC4yLTkA',
 };
 
 export const concordiumWalletTestnet: WalletConnectMobileWallet = {
-    type: 'customLink',
     id: 'ConcordiumTestnet',
     name: 'Concordium Wallet (Testnet)',
     links: {
         native: 'concordiumwallettest://',
     },
-    iconUrl: 'data:image/webp;base64,UklGRhYJAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4IJAIAADwNwCdASr2APYAPpVKmUejIqEU2wQoNAlE9Ld+Pizr+LYWxZS/TBwLdH/K6W0R2gHuBnEX9aexL/V+gdjmAc/GkRS1VumIAPqd6Bfuvmh9edZ2MnaC/rbgdjbmZmZmZmZmZmZmZmZmZmbIZmTyXTucuirhRPGoAfpkGImqqt/3YwASWFmyG/bP9A39oE5zptUrEnIUEPxyb10xsoP3VDW/cPDwzQGMQhPiKDZ/AXJqcA+3qvnRGhVvjzWO38+JZONxLAMSQln7oacp/aGkTP2CI7U//o7VM3pR4MfkbVoOIXAsGwxsynfeCnsnsY8iVDG7KHQosBfI/xrvmdCADpYcI6NG6Jd3sQqZzsYKzIvGarc+4jFmxKnQEkcpfIZUXieXjQT64aW7tr6Vcy+BC7BftL5EN7fDuWTcCh9xPy5oX3jpEyxNGPwoCbL5y2fMA05eDBANchp+zkopFSdgf5a+S6wS5+W5s8tpOsnBgTnAcI9q0uOTEwCjYSa10TYoZpDhXAih5wReIWxxtS51BN4r9t/r+3XAjLG6TB2p8JLlG360tlj26fz2nHbnIgAAAAKIzOg/60pkb+lEZnQV5b5WU7TjXD68QwAA/vS/wEnP/oMKreuAAAAA/WfNc36Y3zMAAAAA2UAO1xjKXsqNaC5HPIM3yNL+BQ8hQt+wxmwpHDKIc3UouEzyT2lywAHIsI8P/5fMoHSq1d5n+dlw8xmDXlr7XrHtkc25rz2ueWwnEYFwfKQaJgoR1kCrRAABtudYDWl5aMRIA2UlZ0bSWrzjlb/mgBql8N3jfgtVK4F3OI2JOw+DqPiRdEjGz8i0AvNomL3KcwP3L7zRmfp2HGZvCYuhR8jyCtWUBABLg6wCm0TkgxpRApBKS5IClkhuF/UnCWUhq5ntDP+oTZlUVCq4qL6A19+rk9AJ6ox/aGKLuCJE/Sys9oJHTWk7bbd2AK+7W+E1x7PDdFRmteme1WcuX5ZW5gSJ/JSuCWT55kLBz3i0JwvcuNtgWif0fPNSB71IEXXsv7Dl0TvZtfItF+V/MljUPJMvk7qqEnsFFcUeYVgT+253x6Lbg2NB+hEdDDCd3b7FIpqYFKB++q3vmLwxDMQH6e5OROxmjWieruIQ9y9uWvkTpoqCvPL10PIDL8NihCdI4ZS293VL7GW2ld4AZeGtrgczeIWwwRRfJMtiRk9hp5SguQCzK6hE2j0i2+MP05g3l0HsvgYLU+OSaLslG9i+oWCVizfJvxSJx6guQQWEfBWPZBi8Y5TwaPKPCD2f74wtejTEeLdmzFg7KAE6ZqSeQPi+cN3rzS+NdGQA+3F7HQKapSmgVJWJ+HPc7WEv9cEIn2i6NNMunpgLp+ZrFpQDqjyWVplxH2n1+lrMiwOJVTTubzRTMAMSP/kkT3tj9LmfHpF7qI+scitZetxN1QTM8NG5zr8fX/UVU/HolSx2YXqIXV5wi/mCGIU7eXZoGxLSeHULMMKZ7c2UmZaE643Tl5HCaO2Ri5lFYbMkwPqqKL33tLVb2Tycl0nQyzihq1M7aVT6KVIDnxDPrCDjEOUI5zsmvqniV0Qp2bPq8frtn/KrhV3sP/L4E7LMM/jcwr5y6yghSOvBDAfLsjgJf7lfwMayafHmmiP+Zj5lz8mtCt8esQm2i1gQrcoziKfYKmGO8qycD9hkNFi5IBEz2J1VMQNkbnTz0ysgf1WSsrxDkhwSHqNcOZAD22Xy7L2IcwqWTTZRxmhOWlp5OP8JkMI2prkoojZ1JbrPRexFlg+2ZFWeBdgxc5OhGqLoL1mnISRyRfZkdugOnxnIB/SiCxhA51Uw4RaE/mVsMsMxt8jQB9/WGWlQ0LBkaCvsdSIBwsKIge6OPK1rvR6N7L/YU0VmHIsjRvO2SBympDY/yS5V4CETf8+0TfGnIo2J1oLqD3BbuZB25s7yTMLtmESRtLB5HbuGhnRjf4Gi69a0ziESm543hKe3+nQiD/jcjXw8VTLb5oe+jIBOpledmLdHXug0OOcSqjoh4GCDN8cka29NCHpxJNhsO0+CTNcIfGBTnvVG2L6SH4QLgVOLsZryT1lungAz2S6V7Yhk3iGHFi1jBZYKwfyNbs0u0S+uYBEl6hhYoobezYRHLlZx+kMEv09+YgDR/056s6m4VjzRhi32AfkbeJnrfX3UEfCbNOBH8xIExiEeU0M2WNfHD0wbEuG3NVB/sqdSAp+jaTYr0TCP6oYjw7opj7NdNfwekPkuyvK5g1x2ijisTDPVh2+ppc8o6//M/EbOi2BP3L2l15/dm/hi1EC51FSzUmrJUkY+v6E8zoT04p124JMHLamYtii9kiVyIx+YDFlHA+UiXH6OtXFo4+sdwUe7kyfaEnTV/7lwShO+U2fPYeJ8e8wQ1iHSMKOYhWaakW+v7wspz2hqgJ4ZiRE5yHobn90KASZBSoxhSFB2mnQSot3UYqpyzonnlyPHSwQ/tmr+P0k+QFMmhreH0APbWTVrLhWLyWx0iVEMQZqG8deFJnUzafelQ/fQKq72PnHlvjZycEw+A2FbPxtc/lyh3OWzh5gMd9vkqVBMUU4tnXS6GDRdqNtRxtzeKw4BwTtfIxsxFJl9t+njZV3GsS+1TRSb5grO9xX84n96SD+YS/GmK9WTdcRLRcvE+nc9KskXTMjD4X4i4aiJE0tzYdngR4870RCRJVSdsWT3lR8U/6q73Ftl/NMG/JoLK28WyADmuj4wLLxchOBptE+cFjRw7Syp4lZdT2a4dZ8yKL6drDCwAQ5Hd+JMSvTck3HvV7OHnG1HJNhYyBKbTsN7eSzry1JxztqGVOxxS9dt1gv3QL0kb/G3KtbxgNfLxS0orOw2Ck3FA0W73AFKAovPp7n2sr4gFItAPoKQIK6uC6gHlvqjZgj3wrT2dgfgY09Sx8oQ/Cdt6TgAAEVYSUZfAAAASUkqAAgAAAABAGmHBAABAAAAGgAAAAAAAAABAIaSBwAyAAAALAAAAAAAAABBU0NJSQAAADEuNzIuMC0yM0otTkFRQkZIMlE3Tk9OQU80QldBN1pHQ05WTUkuMC4yLTkA',
+    iconUrl:
+        'data:image/webp;base64,UklGRhYJAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4IJAIAADwNwCdASr2APYAPpVKmUejIqEU2wQoNAlE9Ld+Pizr+LYWxZS/TBwLdH/K6W0R2gHuBnEX9aexL/V+gdjmAc/GkRS1VumIAPqd6Bfuvmh9edZ2MnaC/rbgdjbmZmZmZmZmZmZmZmZmZmbIZmTyXTucuirhRPGoAfpkGImqqt/3YwASWFmyG/bP9A39oE5zptUrEnIUEPxyb10xsoP3VDW/cPDwzQGMQhPiKDZ/AXJqcA+3qvnRGhVvjzWO38+JZONxLAMSQln7oacp/aGkTP2CI7U//o7VM3pR4MfkbVoOIXAsGwxsynfeCnsnsY8iVDG7KHQosBfI/xrvmdCADpYcI6NG6Jd3sQqZzsYKzIvGarc+4jFmxKnQEkcpfIZUXieXjQT64aW7tr6Vcy+BC7BftL5EN7fDuWTcCh9xPy5oX3jpEyxNGPwoCbL5y2fMA05eDBANchp+zkopFSdgf5a+S6wS5+W5s8tpOsnBgTnAcI9q0uOTEwCjYSa10TYoZpDhXAih5wReIWxxtS51BN4r9t/r+3XAjLG6TB2p8JLlG360tlj26fz2nHbnIgAAAAKIzOg/60pkb+lEZnQV5b5WU7TjXD68QwAA/vS/wEnP/oMKreuAAAAA/WfNc36Y3zMAAAAA2UAO1xjKXsqNaC5HPIM3yNL+BQ8hQt+wxmwpHDKIc3UouEzyT2lywAHIsI8P/5fMoHSq1d5n+dlw8xmDXlr7XrHtkc25rz2ueWwnEYFwfKQaJgoR1kCrRAABtudYDWl5aMRIA2UlZ0bSWrzjlb/mgBql8N3jfgtVK4F3OI2JOw+DqPiRdEjGz8i0AvNomL3KcwP3L7zRmfp2HGZvCYuhR8jyCtWUBABLg6wCm0TkgxpRApBKS5IClkhuF/UnCWUhq5ntDP+oTZlUVCq4qL6A19+rk9AJ6ox/aGKLuCJE/Sys9oJHTWk7bbd2AK+7W+E1x7PDdFRmteme1WcuX5ZW5gSJ/JSuCWT55kLBz3i0JwvcuNtgWif0fPNSB71IEXXsv7Dl0TvZtfItF+V/MljUPJMvk7qqEnsFFcUeYVgT+253x6Lbg2NB+hEdDDCd3b7FIpqYFKB++q3vmLwxDMQH6e5OROxmjWieruIQ9y9uWvkTpoqCvPL10PIDL8NihCdI4ZS293VL7GW2ld4AZeGtrgczeIWwwRRfJMtiRk9hp5SguQCzK6hE2j0i2+MP05g3l0HsvgYLU+OSaLslG9i+oWCVizfJvxSJx6guQQWEfBWPZBi8Y5TwaPKPCD2f74wtejTEeLdmzFg7KAE6ZqSeQPi+cN3rzS+NdGQA+3F7HQKapSmgVJWJ+HPc7WEv9cEIn2i6NNMunpgLp+ZrFpQDqjyWVplxH2n1+lrMiwOJVTTubzRTMAMSP/kkT3tj9LmfHpF7qI+scitZetxN1QTM8NG5zr8fX/UVU/HolSx2YXqIXV5wi/mCGIU7eXZoGxLSeHULMMKZ7c2UmZaE643Tl5HCaO2Ri5lFYbMkwPqqKL33tLVb2Tycl0nQyzihq1M7aVT6KVIDnxDPrCDjEOUI5zsmvqniV0Qp2bPq8frtn/KrhV3sP/L4E7LMM/jcwr5y6yghSOvBDAfLsjgJf7lfwMayafHmmiP+Zj5lz8mtCt8esQm2i1gQrcoziKfYKmGO8qycD9hkNFi5IBEz2J1VMQNkbnTz0ysgf1WSsrxDkhwSHqNcOZAD22Xy7L2IcwqWTTZRxmhOWlp5OP8JkMI2prkoojZ1JbrPRexFlg+2ZFWeBdgxc5OhGqLoL1mnISRyRfZkdugOnxnIB/SiCxhA51Uw4RaE/mVsMsMxt8jQB9/WGWlQ0LBkaCvsdSIBwsKIge6OPK1rvR6N7L/YU0VmHIsjRvO2SBympDY/yS5V4CETf8+0TfGnIo2J1oLqD3BbuZB25s7yTMLtmESRtLB5HbuGhnRjf4Gi69a0ziESm543hKe3+nQiD/jcjXw8VTLb5oe+jIBOpledmLdHXug0OOcSqjoh4GCDN8cka29NCHpxJNhsO0+CTNcIfGBTnvVG2L6SH4QLgVOLsZryT1lungAz2S6V7Yhk3iGHFi1jBZYKwfyNbs0u0S+uYBEl6hhYoobezYRHLlZx+kMEv09+YgDR/056s6m4VjzRhi32AfkbeJnrfX3UEfCbNOBH8xIExiEeU0M2WNfHD0wbEuG3NVB/sqdSAp+jaTYr0TCP6oYjw7opj7NdNfwekPkuyvK5g1x2ijisTDPVh2+ppc8o6//M/EbOi2BP3L2l15/dm/hi1EC51FSzUmrJUkY+v6E8zoT04p124JMHLamYtii9kiVyIx+YDFlHA+UiXH6OtXFo4+sdwUe7kyfaEnTV/7lwShO+U2fPYeJ8e8wQ1iHSMKOYhWaakW+v7wspz2hqgJ4ZiRE5yHobn90KASZBSoxhSFB2mnQSot3UYqpyzonnlyPHSwQ/tmr+P0k+QFMmhreH0APbWTVrLhWLyWx0iVEMQZqG8deFJnUzafelQ/fQKq72PnHlvjZycEw+A2FbPxtc/lyh3OWzh5gMd9vkqVBMUU4tnXS6GDRdqNtRxtzeKw4BwTtfIxsxFJl9t+njZV3GsS+1TRSb5grO9xX84n96SD+YS/GmK9WTdcRLRcvE+nc9KskXTMjD4X4i4aiJE0tzYdngR4870RCRJVSdsWT3lR8U/6q73Ftl/NMG/JoLK28WyADmuj4wLLxchOBptE+cFjRw7Syp4lZdT2a4dZ8yKL6drDCwAQ5Hd+JMSvTck3HvV7OHnG1HJNhYyBKbTsN7eSzry1JxztqGVOxxS9dt1gv3QL0kb/G3KtbxgNfLxS0orOw2Ck3FA0W73AFKAovPp7n2sr4gFItAPoKQIK6uC6gHlvqjZgj3wrT2dgfgY09Sx8oQ/Cdt6TgAAEVYSUZfAAAASUkqAAgAAAABAGmHBAABAAAAGgAAAAAAAAABAIaSBwAyAAAALAAAAAAAAABBU0NJSQAAADEuNzIuMC0yM0otTkFRQkZIMlE3Tk9OQU80QldBN1pHQ05WTUkuMC4yLTkA',
 };
 
 export const cryptoXWalletMainnet: WalletConnectMobileWallet = {
-    type: 'customLink',
     id: 'CryptoXMainnet',
     name: 'CryptoX Wallet',
     links: {
         native: 'cryptox://',
     },
-    iconUrl: 'data:image/webp;base64,UklGRq4IAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4ICgIAAAQOgCdASr2APYAPpVKoEkjIqOSyUxoPAlE9LdwtsRcx/9gEtbFXvJX9o7XP8ry3Exkinwu7z+AF+K/03dWQAfVX0QplKp3QA8Pf6o8/X1n7B/RmGuEjujA2X94H9Ils4eF/eB/TLc1bMOYHponzYnW45tSVbKO4s6aWDbnZBN8etJtH6RwKvug93bxlxPcj46z4/joqBPQeDnhb/V5/qjNeRkPPUHB7yb9N5wUCGnBATC8NnVBCY+A6kfon3gc6wFKZLzZe74G3EGkWnsvHeB+1vbOAXnGDl2WrZY184H2KkfqjNeSoAyzI9bkAKXW8RdUglOxcqDgkw2HdFoFe1gf39eUH2ZcHmWqaEEC5Q4zwqksQgadEONzedgasd2q0UCiLbZiPyuLP79FTWFSDveMUrcgA7Rk2bV+ifeCn8NvX8QVPVu6YRhgPGc+umJoz3u0zP7+c1OXBPhgbX9Xs70D70p/2A/7P91eHdkPWNYB+LpPGMmfeH6LmrWyE+uv8ABHOCEyupPOX1P3GtTGrNUmeP1QaaxV3wb27lEhZ5AVG94m9djgcCF6RwIyAKmE4Frmzhdf7AUkxK3hSpwU9eCp4ddjWvHxA1JH6p6zh4X5DR+qes4eF/eBGAD+/GOOD0ClKcAAAqRdPxubKr/L584gM2R1GGUPwp6dQs3fqadFiNS0+UXHk48GXr/0CA1vPw94tlA/jDnPSJDk6HOAAsSyiUDWyNiAZjhMzhwR1ihKcRvC6+5pZKddwGBppAqmkWV7DxF3fBR9A5Eu/M2jHwlFef+hNvWyPtYroh/q+C/WB6QfX+YxIQAjlZO4N22KbvhaxdAU9d3+yT8RCH68Xg1kXsBu1OdDF1ZKKWK1HjY4uDphi24Y85fjkMRsI+DK6o4r//pgutNgWmCHHMU6mAk4WoR5asz6VBUnJyDq6VYEh7roO4KlLvj0JYmuaD/7k5hBxI1dOXYaeW+wn0Lw856iR7QxYE/0lMgxY6THgo4r3izH6XkipF6ydVm19gJVO+aRBSdgeTiXSb+4jIIms4+iCE1Q8WCt55wrccLop7D1irdreS1BXi6HOxOUmuAygrDzr0oamrmtdwtJT21j29wZLQVRj+80zwjnBv74jwL7ufMlKZTqB3BlsFMbZRHNc9PcP3qR1Hh5vib2Uta8DY05nmmK7KVT4oAmdEYxgWsX8dT1pw0L2zicxRti2UsL7WkSJDc1mtZeeO60ZryALGtlG4neZN/hl2UICIOEh7RHDGv+qOKgJ3aHGPoyA3Lb13L4S8YdcPX44qMPskuduOyHRXgY+jHBw58b0eYbYQSPvpqgfZnSDHkTvCoq9KcHlrmM1268HUGMpBZLpaXoptD5sBWWWZdjgDrrwIbbWq8KxqdkJQbmWU6DesSHDRnoYjaHgXU944Q/02sILCdeIrK/PZHqb1LhcSvN6nhr/YuZybtHMhitfcV+q4ULdjO3TZ0CwtofxNgtKy0z/kzPlrJjSKQyR/oGBdTqLwoBWv5M7An4/oho1b4L0x+gu2gg/mV6T4HJK5dQtyUDzIBUhxfY8bpGOYvkfo3t0ksmG4acz9QJyqcDWwKOjYDtjDwrTz3OQ3OMsZe3GEQ19KHURtuMAsuy97OTzkpMnBrsC8jr2carFvkqs0Y33HGHMHyTbC7YDm5Vsd+BZUIoas5mIiWPUsAxHZ6e3rbbipZflMaAYrigtjfMr0+JMz0qn2AADshftyWH2YERoTT4f67ghSXth68jTZfZyEZ4bBvgo+h/tNWlfzVwgjDTfuEe6xvhzNe4URmp8J2KnxfvspQcRpF9viYYbwf2qkupDhAiPB2XEF5YX6gJqzTCLW/KGN/sCzh0xUP1WTroYsrIUJ/Mwxi/MYPjzAG8DhZNMP/MBw0rhhSt9hx7f8iKgPchSVXEk1jGCzq0vF47tCTFGILFlWa+b4FfEoLrMt6FBK6NKs44+rc78jmgE7fyuKRAS6TtJM8MfSQ0BrODb+W9mEmOqkgTFZWdXcy9YjCCLY1XE2NghV2+HvOnYYsjFh8X25QJJnn3G3JFv3plL0h1IaDVM++QwdqTN9fVD6myV3HOqfUVr0uSK/x6R34xMWDnpYtmM31i2O09aFpm1+v7SXi5va1wc1bgMr0z+CZVIrYg2WsObb8j/I4QKag/VHKIL0uh+vl3k4diQdUgK5OCwkMNswEd/Cj5ZobjWUWVp57tmFL3KMUAHXHs2u/ppJe8Exq7Z/OD4icEULC4A3LgBiZdwPtslgwZKjE2k+HuY/bcQalvgkzthgPUD18YwA+JsSBjt4Kie5j3vgMSwuLCqbKVGfiobimvXFFlWyH1YDQuAITt43hv4K9zIktCZtcQZVJsLD1qoKrZjb3eI+BxYIQNqKN5f8esUE4QdamfUZwLAEOpKKg7q8y9FCm8I361uViycyCX8UhJggyEWLhrnSqQ+jJ/dySd+u6CbimALEYV8+Z+XIT9ZYEf+l7iJEoVxIeKMX8wvhKKVeSgsfo4gRjjNbXfZl8zX+V8mlCTL42h4pFJuSDYQbOP4IEwDkhm0U4CiI30x5PlSM+qE4AWC2CStLSvsObBc7wff1zWNdkAjzKvh03fe/NTVaBFo5da3Mz5i3ppXGIPVphrUIu98U62QNTfberbnpekvG5HP/glYaXO1NqOfjeTt4gUD1Ue+d0OjqGmil1Wot7ueZX48je6PPbGtP1EgCILadHi5Y3XaHGhIy4jUhhIh0TOl4mYkeqyfiTUliyB8Ua+1uMmsxzYkMAAzEfAcoAAAABFWElGXwAAAElJKgAIAAAAAQBphwQAAQAAABoAAAAAAAAAAQCGkgcAMgAAACwAAAAAAAAAQVNDSUkAAAAxLjcyLjEtMjNKLUlBTkxVTzVVT0FTQTNSU0U1UFhCVDRQNkdFLjAuMi01AA==',
+    iconUrl:
+        'data:image/webp;base64,UklGRq4IAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4ICgIAAAQOgCdASr2APYAPpVKoEkjIqOSyUxoPAlE9LdwtsRcx/9gEtbFXvJX9o7XP8ry3Exkinwu7z+AF+K/03dWQAfVX0QplKp3QA8Pf6o8/X1n7B/RmGuEjujA2X94H9Ils4eF/eB/TLc1bMOYHponzYnW45tSVbKO4s6aWDbnZBN8etJtH6RwKvug93bxlxPcj46z4/joqBPQeDnhb/V5/qjNeRkPPUHB7yb9N5wUCGnBATC8NnVBCY+A6kfon3gc6wFKZLzZe74G3EGkWnsvHeB+1vbOAXnGDl2WrZY184H2KkfqjNeSoAyzI9bkAKXW8RdUglOxcqDgkw2HdFoFe1gf39eUH2ZcHmWqaEEC5Q4zwqksQgadEONzedgasd2q0UCiLbZiPyuLP79FTWFSDveMUrcgA7Rk2bV+ifeCn8NvX8QVPVu6YRhgPGc+umJoz3u0zP7+c1OXBPhgbX9Xs70D70p/2A/7P91eHdkPWNYB+LpPGMmfeH6LmrWyE+uv8ABHOCEyupPOX1P3GtTGrNUmeP1QaaxV3wb27lEhZ5AVG94m9djgcCF6RwIyAKmE4Frmzhdf7AUkxK3hSpwU9eCp4ddjWvHxA1JH6p6zh4X5DR+qes4eF/eBGAD+/GOOD0ClKcAAAqRdPxubKr/L584gM2R1GGUPwp6dQs3fqadFiNS0+UXHk48GXr/0CA1vPw94tlA/jDnPSJDk6HOAAsSyiUDWyNiAZjhMzhwR1ihKcRvC6+5pZKddwGBppAqmkWV7DxF3fBR9A5Eu/M2jHwlFef+hNvWyPtYroh/q+C/WB6QfX+YxIQAjlZO4N22KbvhaxdAU9d3+yT8RCH68Xg1kXsBu1OdDF1ZKKWK1HjY4uDphi24Y85fjkMRsI+DK6o4r//pgutNgWmCHHMU6mAk4WoR5asz6VBUnJyDq6VYEh7roO4KlLvj0JYmuaD/7k5hBxI1dOXYaeW+wn0Lw856iR7QxYE/0lMgxY6THgo4r3izH6XkipF6ydVm19gJVO+aRBSdgeTiXSb+4jIIms4+iCE1Q8WCt55wrccLop7D1irdreS1BXi6HOxOUmuAygrDzr0oamrmtdwtJT21j29wZLQVRj+80zwjnBv74jwL7ufMlKZTqB3BlsFMbZRHNc9PcP3qR1Hh5vib2Uta8DY05nmmK7KVT4oAmdEYxgWsX8dT1pw0L2zicxRti2UsL7WkSJDc1mtZeeO60ZryALGtlG4neZN/hl2UICIOEh7RHDGv+qOKgJ3aHGPoyA3Lb13L4S8YdcPX44qMPskuduOyHRXgY+jHBw58b0eYbYQSPvpqgfZnSDHkTvCoq9KcHlrmM1268HUGMpBZLpaXoptD5sBWWWZdjgDrrwIbbWq8KxqdkJQbmWU6DesSHDRnoYjaHgXU944Q/02sILCdeIrK/PZHqb1LhcSvN6nhr/YuZybtHMhitfcV+q4ULdjO3TZ0CwtofxNgtKy0z/kzPlrJjSKQyR/oGBdTqLwoBWv5M7An4/oho1b4L0x+gu2gg/mV6T4HJK5dQtyUDzIBUhxfY8bpGOYvkfo3t0ksmG4acz9QJyqcDWwKOjYDtjDwrTz3OQ3OMsZe3GEQ19KHURtuMAsuy97OTzkpMnBrsC8jr2carFvkqs0Y33HGHMHyTbC7YDm5Vsd+BZUIoas5mIiWPUsAxHZ6e3rbbipZflMaAYrigtjfMr0+JMz0qn2AADshftyWH2YERoTT4f67ghSXth68jTZfZyEZ4bBvgo+h/tNWlfzVwgjDTfuEe6xvhzNe4URmp8J2KnxfvspQcRpF9viYYbwf2qkupDhAiPB2XEF5YX6gJqzTCLW/KGN/sCzh0xUP1WTroYsrIUJ/Mwxi/MYPjzAG8DhZNMP/MBw0rhhSt9hx7f8iKgPchSVXEk1jGCzq0vF47tCTFGILFlWa+b4FfEoLrMt6FBK6NKs44+rc78jmgE7fyuKRAS6TtJM8MfSQ0BrODb+W9mEmOqkgTFZWdXcy9YjCCLY1XE2NghV2+HvOnYYsjFh8X25QJJnn3G3JFv3plL0h1IaDVM++QwdqTN9fVD6myV3HOqfUVr0uSK/x6R34xMWDnpYtmM31i2O09aFpm1+v7SXi5va1wc1bgMr0z+CZVIrYg2WsObb8j/I4QKag/VHKIL0uh+vl3k4diQdUgK5OCwkMNswEd/Cj5ZobjWUWVp57tmFL3KMUAHXHs2u/ppJe8Exq7Z/OD4icEULC4A3LgBiZdwPtslgwZKjE2k+HuY/bcQalvgkzthgPUD18YwA+JsSBjt4Kie5j3vgMSwuLCqbKVGfiobimvXFFlWyH1YDQuAITt43hv4K9zIktCZtcQZVJsLD1qoKrZjb3eI+BxYIQNqKN5f8esUE4QdamfUZwLAEOpKKg7q8y9FCm8I361uViycyCX8UhJggyEWLhrnSqQ+jJ/dySd+u6CbimALEYV8+Z+XIT9ZYEf+l7iJEoVxIeKMX8wvhKKVeSgsfo4gRjjNbXfZl8zX+V8mlCTL42h4pFJuSDYQbOP4IEwDkhm0U4CiI30x5PlSM+qE4AWC2CStLSvsObBc7wff1zWNdkAjzKvh03fe/NTVaBFo5da3Mz5i3ppXGIPVphrUIu98U62QNTfberbnpekvG5HP/glYaXO1NqOfjeTt4gUD1Ue+d0OjqGmil1Wot7ueZX48je6PPbGtP1EgCILadHi5Y3XaHGhIy4jUhhIh0TOl4mYkeqyfiTUliyB8Ua+1uMmsxzYkMAAzEfAcoAAAABFWElGXwAAAElJKgAIAAAAAQBphwQAAQAAABoAAAAAAAAAAQCGkgcAMgAAACwAAAAAAAAAQVNDSUkAAAAxLjcyLjEtMjNKLUlBTkxVTzVVT0FTQTNSU0U1UFhCVDRQNkdFLjAuMi01AA==',
 };
 
 export const cryptoXWalletTestnet: WalletConnectMobileWallet = {
-    type: 'customLink',
     id: 'CryptoXTestnet',
     name: 'CryptoX Wallet (Testnet)',
     links: {
         native: 'cryptoXStage://',
     },
-    iconUrl: 'data:image/webp;base64,UklGRq4IAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4ICgIAAAQOgCdASr2APYAPpVKoEkjIqOSyUxoPAlE9LdwtsRcx/9gEtbFXvJX9o7XP8ry3Exkinwu7z+AF+K/03dWQAfVX0QplKp3QA8Pf6o8/X1n7B/RmGuEjujA2X94H9Ils4eF/eB/TLc1bMOYHponzYnW45tSVbKO4s6aWDbnZBN8etJtH6RwKvug93bxlxPcj46z4/joqBPQeDnhb/V5/qjNeRkPPUHB7yb9N5wUCGnBATC8NnVBCY+A6kfon3gc6wFKZLzZe74G3EGkWnsvHeB+1vbOAXnGDl2WrZY184H2KkfqjNeSoAyzI9bkAKXW8RdUglOxcqDgkw2HdFoFe1gf39eUH2ZcHmWqaEEC5Q4zwqksQgadEONzedgasd2q0UCiLbZiPyuLP79FTWFSDveMUrcgA7Rk2bV+ifeCn8NvX8QVPVu6YRhgPGc+umJoz3u0zP7+c1OXBPhgbX9Xs70D70p/2A/7P91eHdkPWNYB+LpPGMmfeH6LmrWyE+uv8ABHOCEyupPOX1P3GtTGrNUmeP1QaaxV3wb27lEhZ5AVG94m9djgcCF6RwIyAKmE4Frmzhdf7AUkxK3hSpwU9eCp4ddjWvHxA1JH6p6zh4X5DR+qes4eF/eBGAD+/GOOD0ClKcAAAqRdPxubKr/L584gM2R1GGUPwp6dQs3fqadFiNS0+UXHk48GXr/0CA1vPw94tlA/jDnPSJDk6HOAAsSyiUDWyNiAZjhMzhwR1ihKcRvC6+5pZKddwGBppAqmkWV7DxF3fBR9A5Eu/M2jHwlFef+hNvWyPtYroh/q+C/WB6QfX+YxIQAjlZO4N22KbvhaxdAU9d3+yT8RCH68Xg1kXsBu1OdDF1ZKKWK1HjY4uDphi24Y85fjkMRsI+DK6o4r//pgutNgWmCHHMU6mAk4WoR5asz6VBUnJyDq6VYEh7roO4KlLvj0JYmuaD/7k5hBxI1dOXYaeW+wn0Lw856iR7QxYE/0lMgxY6THgo4r3izH6XkipF6ydVm19gJVO+aRBSdgeTiXSb+4jIIms4+iCE1Q8WCt55wrccLop7D1irdreS1BXi6HOxOUmuAygrDzr0oamrmtdwtJT21j29wZLQVRj+80zwjnBv74jwL7ufMlKZTqB3BlsFMbZRHNc9PcP3qR1Hh5vib2Uta8DY05nmmK7KVT4oAmdEYxgWsX8dT1pw0L2zicxRti2UsL7WkSJDc1mtZeeO60ZryALGtlG4neZN/hl2UICIOEh7RHDGv+qOKgJ3aHGPoyA3Lb13L4S8YdcPX44qMPskuduOyHRXgY+jHBw58b0eYbYQSPvpqgfZnSDHkTvCoq9KcHlrmM1268HUGMpBZLpaXoptD5sBWWWZdjgDrrwIbbWq8KxqdkJQbmWU6DesSHDRnoYjaHgXU944Q/02sILCdeIrK/PZHqb1LhcSvN6nhr/YuZybtHMhitfcV+q4ULdjO3TZ0CwtofxNgtKy0z/kzPlrJjSKQyR/oGBdTqLwoBWv5M7An4/oho1b4L0x+gu2gg/mV6T4HJK5dQtyUDzIBUhxfY8bpGOYvkfo3t0ksmG4acz9QJyqcDWwKOjYDtjDwrTz3OQ3OMsZe3GEQ19KHURtuMAsuy97OTzkpMnBrsC8jr2carFvkqs0Y33HGHMHyTbC7YDm5Vsd+BZUIoas5mIiWPUsAxHZ6e3rbbipZflMaAYrigtjfMr0+JMz0qn2AADshftyWH2YERoTT4f67ghSXth68jTZfZyEZ4bBvgo+h/tNWlfzVwgjDTfuEe6xvhzNe4URmp8J2KnxfvspQcRpF9viYYbwf2qkupDhAiPB2XEF5YX6gJqzTCLW/KGN/sCzh0xUP1WTroYsrIUJ/Mwxi/MYPjzAG8DhZNMP/MBw0rhhSt9hx7f8iKgPchSVXEk1jGCzq0vF47tCTFGILFlWa+b4FfEoLrMt6FBK6NKs44+rc78jmgE7fyuKRAS6TtJM8MfSQ0BrODb+W9mEmOqkgTFZWdXcy9YjCCLY1XE2NghV2+HvOnYYsjFh8X25QJJnn3G3JFv3plL0h1IaDVM++QwdqTN9fVD6myV3HOqfUVr0uSK/x6R34xMWDnpYtmM31i2O09aFpm1+v7SXi5va1wc1bgMr0z+CZVIrYg2WsObb8j/I4QKag/VHKIL0uh+vl3k4diQdUgK5OCwkMNswEd/Cj5ZobjWUWVp57tmFL3KMUAHXHs2u/ppJe8Exq7Z/OD4icEULC4A3LgBiZdwPtslgwZKjE2k+HuY/bcQalvgkzthgPUD18YwA+JsSBjt4Kie5j3vgMSwuLCqbKVGfiobimvXFFlWyH1YDQuAITt43hv4K9zIktCZtcQZVJsLD1qoKrZjb3eI+BxYIQNqKN5f8esUE4QdamfUZwLAEOpKKg7q8y9FCm8I361uViycyCX8UhJggyEWLhrnSqQ+jJ/dySd+u6CbimALEYV8+Z+XIT9ZYEf+l7iJEoVxIeKMX8wvhKKVeSgsfo4gRjjNbXfZl8zX+V8mlCTL42h4pFJuSDYQbOP4IEwDkhm0U4CiI30x5PlSM+qE4AWC2CStLSvsObBc7wff1zWNdkAjzKvh03fe/NTVaBFo5da3Mz5i3ppXGIPVphrUIu98U62QNTfberbnpekvG5HP/glYaXO1NqOfjeTt4gUD1Ue+d0OjqGmil1Wot7ueZX48je6PPbGtP1EgCILadHi5Y3XaHGhIy4jUhhIh0TOl4mYkeqyfiTUliyB8Ua+1uMmsxzYkMAAzEfAcoAAAABFWElGXwAAAElJKgAIAAAAAQBphwQAAQAAABoAAAAAAAAAAQCGkgcAMgAAACwAAAAAAAAAQVNDSUkAAAAxLjcyLjEtMjNKLUlBTkxVTzVVT0FTQTNSU0U1UFhCVDRQNkdFLjAuMi01AA==',
+    iconUrl:
+        'data:image/webp;base64,UklGRq4IAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4ICgIAAAQOgCdASr2APYAPpVKoEkjIqOSyUxoPAlE9LdwtsRcx/9gEtbFXvJX9o7XP8ry3Exkinwu7z+AF+K/03dWQAfVX0QplKp3QA8Pf6o8/X1n7B/RmGuEjujA2X94H9Ils4eF/eB/TLc1bMOYHponzYnW45tSVbKO4s6aWDbnZBN8etJtH6RwKvug93bxlxPcj46z4/joqBPQeDnhb/V5/qjNeRkPPUHB7yb9N5wUCGnBATC8NnVBCY+A6kfon3gc6wFKZLzZe74G3EGkWnsvHeB+1vbOAXnGDl2WrZY184H2KkfqjNeSoAyzI9bkAKXW8RdUglOxcqDgkw2HdFoFe1gf39eUH2ZcHmWqaEEC5Q4zwqksQgadEONzedgasd2q0UCiLbZiPyuLP79FTWFSDveMUrcgA7Rk2bV+ifeCn8NvX8QVPVu6YRhgPGc+umJoz3u0zP7+c1OXBPhgbX9Xs70D70p/2A/7P91eHdkPWNYB+LpPGMmfeH6LmrWyE+uv8ABHOCEyupPOX1P3GtTGrNUmeP1QaaxV3wb27lEhZ5AVG94m9djgcCF6RwIyAKmE4Frmzhdf7AUkxK3hSpwU9eCp4ddjWvHxA1JH6p6zh4X5DR+qes4eF/eBGAD+/GOOD0ClKcAAAqRdPxubKr/L584gM2R1GGUPwp6dQs3fqadFiNS0+UXHk48GXr/0CA1vPw94tlA/jDnPSJDk6HOAAsSyiUDWyNiAZjhMzhwR1ihKcRvC6+5pZKddwGBppAqmkWV7DxF3fBR9A5Eu/M2jHwlFef+hNvWyPtYroh/q+C/WB6QfX+YxIQAjlZO4N22KbvhaxdAU9d3+yT8RCH68Xg1kXsBu1OdDF1ZKKWK1HjY4uDphi24Y85fjkMRsI+DK6o4r//pgutNgWmCHHMU6mAk4WoR5asz6VBUnJyDq6VYEh7roO4KlLvj0JYmuaD/7k5hBxI1dOXYaeW+wn0Lw856iR7QxYE/0lMgxY6THgo4r3izH6XkipF6ydVm19gJVO+aRBSdgeTiXSb+4jIIms4+iCE1Q8WCt55wrccLop7D1irdreS1BXi6HOxOUmuAygrDzr0oamrmtdwtJT21j29wZLQVRj+80zwjnBv74jwL7ufMlKZTqB3BlsFMbZRHNc9PcP3qR1Hh5vib2Uta8DY05nmmK7KVT4oAmdEYxgWsX8dT1pw0L2zicxRti2UsL7WkSJDc1mtZeeO60ZryALGtlG4neZN/hl2UICIOEh7RHDGv+qOKgJ3aHGPoyA3Lb13L4S8YdcPX44qMPskuduOyHRXgY+jHBw58b0eYbYQSPvpqgfZnSDHkTvCoq9KcHlrmM1268HUGMpBZLpaXoptD5sBWWWZdjgDrrwIbbWq8KxqdkJQbmWU6DesSHDRnoYjaHgXU944Q/02sILCdeIrK/PZHqb1LhcSvN6nhr/YuZybtHMhitfcV+q4ULdjO3TZ0CwtofxNgtKy0z/kzPlrJjSKQyR/oGBdTqLwoBWv5M7An4/oho1b4L0x+gu2gg/mV6T4HJK5dQtyUDzIBUhxfY8bpGOYvkfo3t0ksmG4acz9QJyqcDWwKOjYDtjDwrTz3OQ3OMsZe3GEQ19KHURtuMAsuy97OTzkpMnBrsC8jr2carFvkqs0Y33HGHMHyTbC7YDm5Vsd+BZUIoas5mIiWPUsAxHZ6e3rbbipZflMaAYrigtjfMr0+JMz0qn2AADshftyWH2YERoTT4f67ghSXth68jTZfZyEZ4bBvgo+h/tNWlfzVwgjDTfuEe6xvhzNe4URmp8J2KnxfvspQcRpF9viYYbwf2qkupDhAiPB2XEF5YX6gJqzTCLW/KGN/sCzh0xUP1WTroYsrIUJ/Mwxi/MYPjzAG8DhZNMP/MBw0rhhSt9hx7f8iKgPchSVXEk1jGCzq0vF47tCTFGILFlWa+b4FfEoLrMt6FBK6NKs44+rc78jmgE7fyuKRAS6TtJM8MfSQ0BrODb+W9mEmOqkgTFZWdXcy9YjCCLY1XE2NghV2+HvOnYYsjFh8X25QJJnn3G3JFv3plL0h1IaDVM++QwdqTN9fVD6myV3HOqfUVr0uSK/x6R34xMWDnpYtmM31i2O09aFpm1+v7SXi5va1wc1bgMr0z+CZVIrYg2WsObb8j/I4QKag/VHKIL0uh+vl3k4diQdUgK5OCwkMNswEd/Cj5ZobjWUWVp57tmFL3KMUAHXHs2u/ppJe8Exq7Z/OD4icEULC4A3LgBiZdwPtslgwZKjE2k+HuY/bcQalvgkzthgPUD18YwA+JsSBjt4Kie5j3vgMSwuLCqbKVGfiobimvXFFlWyH1YDQuAITt43hv4K9zIktCZtcQZVJsLD1qoKrZjb3eI+BxYIQNqKN5f8esUE4QdamfUZwLAEOpKKg7q8y9FCm8I361uViycyCX8UhJggyEWLhrnSqQ+jJ/dySd+u6CbimALEYV8+Z+XIT9ZYEf+l7iJEoVxIeKMX8wvhKKVeSgsfo4gRjjNbXfZl8zX+V8mlCTL42h4pFJuSDYQbOP4IEwDkhm0U4CiI30x5PlSM+qE4AWC2CStLSvsObBc7wff1zWNdkAjzKvh03fe/NTVaBFo5da3Mz5i3ppXGIPVphrUIu98U62QNTfberbnpekvG5HP/glYaXO1NqOfjeTt4gUD1Ue+d0OjqGmil1Wot7ueZX48je6PPbGtP1EgCILadHi5Y3XaHGhIy4jUhhIh0TOl4mYkeqyfiTUliyB8Ua+1uMmsxzYkMAAzEfAcoAAAABFWElGXwAAAElJKgAIAAAAAQBphwQAAQAAABoAAAAAAAAAAQCGkgcAMgAAACwAAAAAAAAAQVNDSUkAAAAxLjcyLjEtMjNKLUlBTkxVTzVVT0FTQTNSU0U1UFhCVDRQNkdFLjAuMi01AA==',
 };
 
 async function connect(
     client: ISignClient,
     scope: ProposalTypes.RequiredNamespace,
     cancel: () => void,
-    mobileWallets?: WalletConnectMobileWallet[]
+    mobileWallets?: WalletConnectMobileWallet[],
+    enableExplorer = false
 ) {
     let modal: WalletConnectModal | undefined;
 
     const wallets: MobileWallet[] = [];
-    const explorerIds: string[] = [];
     const walletImages: Record<string, string> = {};
-    mobileWallets?.forEach(w => {
-        if (w.type === 'explorerId') {
-            explorerIds.push(w.value);
-        } else {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { type: _, iconUrl, ...mw } = w;
-            wallets.push(mw);
-            if (iconUrl !== undefined) {
-                walletImages[mw.id] = iconUrl;
-            }
+    mobileWallets?.forEach((w) => {
+        const { iconUrl, ...mw } = w;
+        wallets.push(mw);
+        if (iconUrl !== undefined) {
+            walletImages[mw.id] = iconUrl;
         }
     });
 
@@ -140,9 +133,10 @@ async function connect(
                 chains: scope.chains,
                 mobileWallets: wallets,
                 desktopWallets: [],
-                explorerRecommendedWalletIds: explorerIds,
+                explorerRecommendedWalletIds: 'NONE',
                 explorerExcludedWalletIds: 'ALL',
-                walletImages
+                walletImages,
+                enableExplorer,
             });
             // Open modal as we're not connecting to an existing pairing.
             modal.openModal({ uri });
@@ -512,14 +506,16 @@ export class WalletConnectConnector implements WalletConnector {
      *
      * @param methods - The methods to request permission to use for in the wallet
      * @param events - The events to request permission to read from the wallet
-     * @param mobileWallets - The (mobile) wallets to be selectable from the walletconnect modal
+     * @param [mobileWallets] - The (mobile) wallets to be selectable from the walletconnect modal
+     * @param [enableExplorer] - Whether to enable the wallet connect explorer. Defaults to false
      *
      * @returns the {@linkcode WalletConnectConnection}, or `undefined` if rejected from the wallet.
      */
     async connectWithScope(
         methods: WalletConnectMethods[],
         events: WalletConnectEvents[],
-        mobileWallets?: WalletConnectMobileWallet[]
+        mobileWallets?: WalletConnectMobileWallet[],
+        enableExplorer = false
     ) {
         const { name } = this.network;
 
@@ -530,7 +526,7 @@ export class WalletConnectConnector implements WalletConnector {
             events: events,
         };
         const session = await new Promise<SessionTypes.Struct | undefined>((resolve) => {
-            connect(this.client, scope, () => resolve(undefined), mobileWallets).then(resolve);
+            connect(this.client, scope, () => resolve(undefined), mobileWallets, enableExplorer).then(resolve);
         });
         if (!session) {
             // Connect was cancelled.
@@ -553,7 +549,11 @@ export class WalletConnectConnector implements WalletConnector {
                 WalletConnectMethods.RequestVerifiablePresentation,
             ],
             [WalletConnectEvents.AccountsChanged, WalletConnectEvents.ChainChanged],
-            [cryptoXWalletMainnet, concordiumWalletMainnet]
+            this.network === MAINNET
+                ? [cryptoXWalletMainnet, concordiumWalletMainnet]
+                : this.network === TESTNET
+                    ? [cryptoXWalletTestnet, concordiumWalletTestnet]
+                    : undefined
         );
     }
 

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -53,13 +53,10 @@ export const enum WalletConnectEvents {
 
 type WalletConnectMobileWallet = MobileWallet | string;
 
-export const concordiumWallet: MobileWallet = {
-    id: '7dcb0e5eb1b4fc6e2e0b143201c489ea6c618259f49527527d4a349d1a95ba7b', // https://explorer.walletconnect.com/?search=concordium
-    name: 'Concordium Wallet',
-    links: {
-        native: 'concordiumwallet://',
-    },
-};
+/**
+ * 
+ */
+export const concordiumWallet = '7dcb0e5eb1b4fc6e2e0b143201c489ea6c618259f49527527d4a349d1a95ba7b';
 
 export const cryptoXWallet: MobileWallet = {
     id: 'CryptoXWallet',
@@ -466,10 +463,19 @@ export class WalletConnectConnector implements WalletConnector {
         return new WalletConnectConnector(client, delegate, network);
     }
 
+    /**
+     * Connects to wallet connect with the configuration provided by the parameters
+     *
+     * @param methods - The methods to request permission to use for in the wallet
+     * @param events - The events to request permission to read from the wallet
+     * @param mobileWallets - The (mobile) wallets to be selectable from the walletconnect modal
+     *
+     * @returns the {@linkcode WalletConnectConnection}, or `undefined` if rejected from the wallet. 
+     */
     async connectWithScope(
         methods: WalletConnectMethods[],
         events: WalletConnectEvents[],
-        mobileWallets?: MobileWallet[]
+        mobileWallets?: WalletConnectMobileWallet[]
     ) {
         const { name } = this.network;
 
@@ -492,6 +498,9 @@ export class WalletConnectConnector implements WalletConnector {
         return connection;
     }
 
+    /**
+     * Like {@linkcode WalletConnectConnector.connectWithScope}, but with permission to use all methods and read all events.
+     */
     async connect() {
         return this.connectWithScope(
             [
@@ -499,7 +508,8 @@ export class WalletConnectConnector implements WalletConnector {
                 WalletConnectMethods.SignMessage,
                 WalletConnectMethods.RequestVerifiablePresentation,
             ],
-            [WalletConnectEvents.AccountsChanged, WalletConnectEvents.ChainChanged]
+            [WalletConnectEvents.AccountsChanged, WalletConnectEvents.ChainChanged],
+            [cryptoXWallet, concordiumWallet]
         );
     }
 

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -40,16 +40,22 @@ import { UnreachableCaseError } from './error';
 
 const WALLET_CONNECT_SESSION_NAMESPACE = 'ccd';
 
-export const enum WalletConnectMethods {
-    SignAndSendTransaction = 'sign_and_send_transaction',
-    SignMessage = 'sign_message',
-    RequestVerifiablePresentation = 'request_verifiable_presentation',
-}
+// Enums are declared this way to support proper tree shaking
+export const WalletConnectMethods = {
+    SignAndSendTransaction: 'sign_and_send_transaction',
+    SignMessage: 'sign_message',
+    RequestVerifiablePresentation: 'request_verifiable_presentation',
+} as const;
 
-export const enum WalletConnectEvents {
-    ChainChanged = 'chain_changed',
-    AccountsChanged = 'accounts_changed',
-}
+export const WalletConnectEvents = {
+    ChainChanged: 'chain_changed',
+    AccountsChanged: 'accounts_changed',
+} as const;
+
+// intentionally naming the variable the same as the type
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type WalletConnectMethods = typeof WalletConnectMethods[keyof typeof WalletConnectMethods];
+export type WalletConnectEvents = typeof WalletConnectEvents[keyof typeof WalletConnectEvents];
 
 type WalletConnectMobileWallet = MobileWallet | string;
 

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -57,19 +57,51 @@ export const WalletConnectEvents = {
 export type WalletConnectMethods = typeof WalletConnectMethods[keyof typeof WalletConnectMethods];
 export type WalletConnectEvents = typeof WalletConnectEvents[keyof typeof WalletConnectEvents];
 
-type WalletConnectMobileWallet = MobileWallet | string;
+export type WalletConnectMobileWallet =
+    | (MobileWallet & {
+        type: 'customLink';
+        /** Url for an icon to represent the wallet */
+        iconUrl?: string;
+    })
+    | {
+        type: 'explorerId';
+        /** The ID of the wallet in the wallet connect explorer: https://explorer.walletconnect.com/ */
+        value: string;
+    };
 
-/**
- * 
- */
-export const concordiumWallet = '7dcb0e5eb1b4fc6e2e0b143201c489ea6c618259f49527527d4a349d1a95ba7b';
+export const concordiumWalletMainnet: WalletConnectMobileWallet = {
+    type: 'explorerId',
+    value: '7dcb0e5eb1b4fc6e2e0b143201c489ea6c618259f49527527d4a349d1a95ba7b',
+};
 
-export const cryptoXWallet: MobileWallet = {
-    id: 'CryptoXWallet',
+export const concordiumWalletTestnet: WalletConnectMobileWallet = {
+    type: 'customLink',
+    id: 'ConcordiumTestnet',
+    name: 'Concordium Wallet (Testnet)',
+    links: {
+        native: 'concordiumwallettest://',
+    },
+    iconUrl: 'data:image/webp;base64,UklGRhYJAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4IJAIAADwNwCdASr2APYAPpVKmUejIqEU2wQoNAlE9Ld+Pizr+LYWxZS/TBwLdH/K6W0R2gHuBnEX9aexL/V+gdjmAc/GkRS1VumIAPqd6Bfuvmh9edZ2MnaC/rbgdjbmZmZmZmZmZmZmZmZmZmbIZmTyXTucuirhRPGoAfpkGImqqt/3YwASWFmyG/bP9A39oE5zptUrEnIUEPxyb10xsoP3VDW/cPDwzQGMQhPiKDZ/AXJqcA+3qvnRGhVvjzWO38+JZONxLAMSQln7oacp/aGkTP2CI7U//o7VM3pR4MfkbVoOIXAsGwxsynfeCnsnsY8iVDG7KHQosBfI/xrvmdCADpYcI6NG6Jd3sQqZzsYKzIvGarc+4jFmxKnQEkcpfIZUXieXjQT64aW7tr6Vcy+BC7BftL5EN7fDuWTcCh9xPy5oX3jpEyxNGPwoCbL5y2fMA05eDBANchp+zkopFSdgf5a+S6wS5+W5s8tpOsnBgTnAcI9q0uOTEwCjYSa10TYoZpDhXAih5wReIWxxtS51BN4r9t/r+3XAjLG6TB2p8JLlG360tlj26fz2nHbnIgAAAAKIzOg/60pkb+lEZnQV5b5WU7TjXD68QwAA/vS/wEnP/oMKreuAAAAA/WfNc36Y3zMAAAAA2UAO1xjKXsqNaC5HPIM3yNL+BQ8hQt+wxmwpHDKIc3UouEzyT2lywAHIsI8P/5fMoHSq1d5n+dlw8xmDXlr7XrHtkc25rz2ueWwnEYFwfKQaJgoR1kCrRAABtudYDWl5aMRIA2UlZ0bSWrzjlb/mgBql8N3jfgtVK4F3OI2JOw+DqPiRdEjGz8i0AvNomL3KcwP3L7zRmfp2HGZvCYuhR8jyCtWUBABLg6wCm0TkgxpRApBKS5IClkhuF/UnCWUhq5ntDP+oTZlUVCq4qL6A19+rk9AJ6ox/aGKLuCJE/Sys9oJHTWk7bbd2AK+7W+E1x7PDdFRmteme1WcuX5ZW5gSJ/JSuCWT55kLBz3i0JwvcuNtgWif0fPNSB71IEXXsv7Dl0TvZtfItF+V/MljUPJMvk7qqEnsFFcUeYVgT+253x6Lbg2NB+hEdDDCd3b7FIpqYFKB++q3vmLwxDMQH6e5OROxmjWieruIQ9y9uWvkTpoqCvPL10PIDL8NihCdI4ZS293VL7GW2ld4AZeGtrgczeIWwwRRfJMtiRk9hp5SguQCzK6hE2j0i2+MP05g3l0HsvgYLU+OSaLslG9i+oWCVizfJvxSJx6guQQWEfBWPZBi8Y5TwaPKPCD2f74wtejTEeLdmzFg7KAE6ZqSeQPi+cN3rzS+NdGQA+3F7HQKapSmgVJWJ+HPc7WEv9cEIn2i6NNMunpgLp+ZrFpQDqjyWVplxH2n1+lrMiwOJVTTubzRTMAMSP/kkT3tj9LmfHpF7qI+scitZetxN1QTM8NG5zr8fX/UVU/HolSx2YXqIXV5wi/mCGIU7eXZoGxLSeHULMMKZ7c2UmZaE643Tl5HCaO2Ri5lFYbMkwPqqKL33tLVb2Tycl0nQyzihq1M7aVT6KVIDnxDPrCDjEOUI5zsmvqniV0Qp2bPq8frtn/KrhV3sP/L4E7LMM/jcwr5y6yghSOvBDAfLsjgJf7lfwMayafHmmiP+Zj5lz8mtCt8esQm2i1gQrcoziKfYKmGO8qycD9hkNFi5IBEz2J1VMQNkbnTz0ysgf1WSsrxDkhwSHqNcOZAD22Xy7L2IcwqWTTZRxmhOWlp5OP8JkMI2prkoojZ1JbrPRexFlg+2ZFWeBdgxc5OhGqLoL1mnISRyRfZkdugOnxnIB/SiCxhA51Uw4RaE/mVsMsMxt8jQB9/WGWlQ0LBkaCvsdSIBwsKIge6OPK1rvR6N7L/YU0VmHIsjRvO2SBympDY/yS5V4CETf8+0TfGnIo2J1oLqD3BbuZB25s7yTMLtmESRtLB5HbuGhnRjf4Gi69a0ziESm543hKe3+nQiD/jcjXw8VTLb5oe+jIBOpledmLdHXug0OOcSqjoh4GCDN8cka29NCHpxJNhsO0+CTNcIfGBTnvVG2L6SH4QLgVOLsZryT1lungAz2S6V7Yhk3iGHFi1jBZYKwfyNbs0u0S+uYBEl6hhYoobezYRHLlZx+kMEv09+YgDR/056s6m4VjzRhi32AfkbeJnrfX3UEfCbNOBH8xIExiEeU0M2WNfHD0wbEuG3NVB/sqdSAp+jaTYr0TCP6oYjw7opj7NdNfwekPkuyvK5g1x2ijisTDPVh2+ppc8o6//M/EbOi2BP3L2l15/dm/hi1EC51FSzUmrJUkY+v6E8zoT04p124JMHLamYtii9kiVyIx+YDFlHA+UiXH6OtXFo4+sdwUe7kyfaEnTV/7lwShO+U2fPYeJ8e8wQ1iHSMKOYhWaakW+v7wspz2hqgJ4ZiRE5yHobn90KASZBSoxhSFB2mnQSot3UYqpyzonnlyPHSwQ/tmr+P0k+QFMmhreH0APbWTVrLhWLyWx0iVEMQZqG8deFJnUzafelQ/fQKq72PnHlvjZycEw+A2FbPxtc/lyh3OWzh5gMd9vkqVBMUU4tnXS6GDRdqNtRxtzeKw4BwTtfIxsxFJl9t+njZV3GsS+1TRSb5grO9xX84n96SD+YS/GmK9WTdcRLRcvE+nc9KskXTMjD4X4i4aiJE0tzYdngR4870RCRJVSdsWT3lR8U/6q73Ftl/NMG/JoLK28WyADmuj4wLLxchOBptE+cFjRw7Syp4lZdT2a4dZ8yKL6drDCwAQ5Hd+JMSvTck3HvV7OHnG1HJNhYyBKbTsN7eSzry1JxztqGVOxxS9dt1gv3QL0kb/G3KtbxgNfLxS0orOw2Ck3FA0W73AFKAovPp7n2sr4gFItAPoKQIK6uC6gHlvqjZgj3wrT2dgfgY09Sx8oQ/Cdt6TgAAEVYSUZfAAAASUkqAAgAAAABAGmHBAABAAAAGgAAAAAAAAABAIaSBwAyAAAALAAAAAAAAABBU0NJSQAAADEuNzIuMC0yM0otTkFRQkZIMlE3Tk9OQU80QldBN1pHQ05WTUkuMC4yLTkA',
+};
+
+export const cryptoXWalletMainnet: WalletConnectMobileWallet = {
+    type: 'customLink',
+    id: 'CryptoXMainnet',
     name: 'CryptoX Wallet',
     links: {
         native: 'cryptox://',
     },
+    iconUrl: 'data:image/webp;base64,UklGRq4IAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4ICgIAAAQOgCdASr2APYAPpVKoEkjIqOSyUxoPAlE9LdwtsRcx/9gEtbFXvJX9o7XP8ry3Exkinwu7z+AF+K/03dWQAfVX0QplKp3QA8Pf6o8/X1n7B/RmGuEjujA2X94H9Ils4eF/eB/TLc1bMOYHponzYnW45tSVbKO4s6aWDbnZBN8etJtH6RwKvug93bxlxPcj46z4/joqBPQeDnhb/V5/qjNeRkPPUHB7yb9N5wUCGnBATC8NnVBCY+A6kfon3gc6wFKZLzZe74G3EGkWnsvHeB+1vbOAXnGDl2WrZY184H2KkfqjNeSoAyzI9bkAKXW8RdUglOxcqDgkw2HdFoFe1gf39eUH2ZcHmWqaEEC5Q4zwqksQgadEONzedgasd2q0UCiLbZiPyuLP79FTWFSDveMUrcgA7Rk2bV+ifeCn8NvX8QVPVu6YRhgPGc+umJoz3u0zP7+c1OXBPhgbX9Xs70D70p/2A/7P91eHdkPWNYB+LpPGMmfeH6LmrWyE+uv8ABHOCEyupPOX1P3GtTGrNUmeP1QaaxV3wb27lEhZ5AVG94m9djgcCF6RwIyAKmE4Frmzhdf7AUkxK3hSpwU9eCp4ddjWvHxA1JH6p6zh4X5DR+qes4eF/eBGAD+/GOOD0ClKcAAAqRdPxubKr/L584gM2R1GGUPwp6dQs3fqadFiNS0+UXHk48GXr/0CA1vPw94tlA/jDnPSJDk6HOAAsSyiUDWyNiAZjhMzhwR1ihKcRvC6+5pZKddwGBppAqmkWV7DxF3fBR9A5Eu/M2jHwlFef+hNvWyPtYroh/q+C/WB6QfX+YxIQAjlZO4N22KbvhaxdAU9d3+yT8RCH68Xg1kXsBu1OdDF1ZKKWK1HjY4uDphi24Y85fjkMRsI+DK6o4r//pgutNgWmCHHMU6mAk4WoR5asz6VBUnJyDq6VYEh7roO4KlLvj0JYmuaD/7k5hBxI1dOXYaeW+wn0Lw856iR7QxYE/0lMgxY6THgo4r3izH6XkipF6ydVm19gJVO+aRBSdgeTiXSb+4jIIms4+iCE1Q8WCt55wrccLop7D1irdreS1BXi6HOxOUmuAygrDzr0oamrmtdwtJT21j29wZLQVRj+80zwjnBv74jwL7ufMlKZTqB3BlsFMbZRHNc9PcP3qR1Hh5vib2Uta8DY05nmmK7KVT4oAmdEYxgWsX8dT1pw0L2zicxRti2UsL7WkSJDc1mtZeeO60ZryALGtlG4neZN/hl2UICIOEh7RHDGv+qOKgJ3aHGPoyA3Lb13L4S8YdcPX44qMPskuduOyHRXgY+jHBw58b0eYbYQSPvpqgfZnSDHkTvCoq9KcHlrmM1268HUGMpBZLpaXoptD5sBWWWZdjgDrrwIbbWq8KxqdkJQbmWU6DesSHDRnoYjaHgXU944Q/02sILCdeIrK/PZHqb1LhcSvN6nhr/YuZybtHMhitfcV+q4ULdjO3TZ0CwtofxNgtKy0z/kzPlrJjSKQyR/oGBdTqLwoBWv5M7An4/oho1b4L0x+gu2gg/mV6T4HJK5dQtyUDzIBUhxfY8bpGOYvkfo3t0ksmG4acz9QJyqcDWwKOjYDtjDwrTz3OQ3OMsZe3GEQ19KHURtuMAsuy97OTzkpMnBrsC8jr2carFvkqs0Y33HGHMHyTbC7YDm5Vsd+BZUIoas5mIiWPUsAxHZ6e3rbbipZflMaAYrigtjfMr0+JMz0qn2AADshftyWH2YERoTT4f67ghSXth68jTZfZyEZ4bBvgo+h/tNWlfzVwgjDTfuEe6xvhzNe4URmp8J2KnxfvspQcRpF9viYYbwf2qkupDhAiPB2XEF5YX6gJqzTCLW/KGN/sCzh0xUP1WTroYsrIUJ/Mwxi/MYPjzAG8DhZNMP/MBw0rhhSt9hx7f8iKgPchSVXEk1jGCzq0vF47tCTFGILFlWa+b4FfEoLrMt6FBK6NKs44+rc78jmgE7fyuKRAS6TtJM8MfSQ0BrODb+W9mEmOqkgTFZWdXcy9YjCCLY1XE2NghV2+HvOnYYsjFh8X25QJJnn3G3JFv3plL0h1IaDVM++QwdqTN9fVD6myV3HOqfUVr0uSK/x6R34xMWDnpYtmM31i2O09aFpm1+v7SXi5va1wc1bgMr0z+CZVIrYg2WsObb8j/I4QKag/VHKIL0uh+vl3k4diQdUgK5OCwkMNswEd/Cj5ZobjWUWVp57tmFL3KMUAHXHs2u/ppJe8Exq7Z/OD4icEULC4A3LgBiZdwPtslgwZKjE2k+HuY/bcQalvgkzthgPUD18YwA+JsSBjt4Kie5j3vgMSwuLCqbKVGfiobimvXFFlWyH1YDQuAITt43hv4K9zIktCZtcQZVJsLD1qoKrZjb3eI+BxYIQNqKN5f8esUE4QdamfUZwLAEOpKKg7q8y9FCm8I361uViycyCX8UhJggyEWLhrnSqQ+jJ/dySd+u6CbimALEYV8+Z+XIT9ZYEf+l7iJEoVxIeKMX8wvhKKVeSgsfo4gRjjNbXfZl8zX+V8mlCTL42h4pFJuSDYQbOP4IEwDkhm0U4CiI30x5PlSM+qE4AWC2CStLSvsObBc7wff1zWNdkAjzKvh03fe/NTVaBFo5da3Mz5i3ppXGIPVphrUIu98U62QNTfberbnpekvG5HP/glYaXO1NqOfjeTt4gUD1Ue+d0OjqGmil1Wot7ueZX48je6PPbGtP1EgCILadHi5Y3XaHGhIy4jUhhIh0TOl4mYkeqyfiTUliyB8Ua+1uMmsxzYkMAAzEfAcoAAAABFWElGXwAAAElJKgAIAAAAAQBphwQAAQAAABoAAAAAAAAAAQCGkgcAMgAAACwAAAAAAAAAQVNDSUkAAAAxLjcyLjEtMjNKLUlBTkxVTzVVT0FTQTNSU0U1UFhCVDRQNkdFLjAuMi01AA==',
+};
+
+export const cryptoXWalletTestnet: WalletConnectMobileWallet = {
+    type: 'customLink',
+    id: 'CryptoXTestnet',
+    name: 'CryptoX Wallet (Testnet)',
+    links: {
+        native: 'cryptoXStage://',
+    },
+    iconUrl: 'data:image/webp;base64,UklGRq4IAABXRUJQVlA4WAoAAAAIAAAA9QAA9QAAVlA4ICgIAAAQOgCdASr2APYAPpVKoEkjIqOSyUxoPAlE9LdwtsRcx/9gEtbFXvJX9o7XP8ry3Exkinwu7z+AF+K/03dWQAfVX0QplKp3QA8Pf6o8/X1n7B/RmGuEjujA2X94H9Ils4eF/eB/TLc1bMOYHponzYnW45tSVbKO4s6aWDbnZBN8etJtH6RwKvug93bxlxPcj46z4/joqBPQeDnhb/V5/qjNeRkPPUHB7yb9N5wUCGnBATC8NnVBCY+A6kfon3gc6wFKZLzZe74G3EGkWnsvHeB+1vbOAXnGDl2WrZY184H2KkfqjNeSoAyzI9bkAKXW8RdUglOxcqDgkw2HdFoFe1gf39eUH2ZcHmWqaEEC5Q4zwqksQgadEONzedgasd2q0UCiLbZiPyuLP79FTWFSDveMUrcgA7Rk2bV+ifeCn8NvX8QVPVu6YRhgPGc+umJoz3u0zP7+c1OXBPhgbX9Xs70D70p/2A/7P91eHdkPWNYB+LpPGMmfeH6LmrWyE+uv8ABHOCEyupPOX1P3GtTGrNUmeP1QaaxV3wb27lEhZ5AVG94m9djgcCF6RwIyAKmE4Frmzhdf7AUkxK3hSpwU9eCp4ddjWvHxA1JH6p6zh4X5DR+qes4eF/eBGAD+/GOOD0ClKcAAAqRdPxubKr/L584gM2R1GGUPwp6dQs3fqadFiNS0+UXHk48GXr/0CA1vPw94tlA/jDnPSJDk6HOAAsSyiUDWyNiAZjhMzhwR1ihKcRvC6+5pZKddwGBppAqmkWV7DxF3fBR9A5Eu/M2jHwlFef+hNvWyPtYroh/q+C/WB6QfX+YxIQAjlZO4N22KbvhaxdAU9d3+yT8RCH68Xg1kXsBu1OdDF1ZKKWK1HjY4uDphi24Y85fjkMRsI+DK6o4r//pgutNgWmCHHMU6mAk4WoR5asz6VBUnJyDq6VYEh7roO4KlLvj0JYmuaD/7k5hBxI1dOXYaeW+wn0Lw856iR7QxYE/0lMgxY6THgo4r3izH6XkipF6ydVm19gJVO+aRBSdgeTiXSb+4jIIms4+iCE1Q8WCt55wrccLop7D1irdreS1BXi6HOxOUmuAygrDzr0oamrmtdwtJT21j29wZLQVRj+80zwjnBv74jwL7ufMlKZTqB3BlsFMbZRHNc9PcP3qR1Hh5vib2Uta8DY05nmmK7KVT4oAmdEYxgWsX8dT1pw0L2zicxRti2UsL7WkSJDc1mtZeeO60ZryALGtlG4neZN/hl2UICIOEh7RHDGv+qOKgJ3aHGPoyA3Lb13L4S8YdcPX44qMPskuduOyHRXgY+jHBw58b0eYbYQSPvpqgfZnSDHkTvCoq9KcHlrmM1268HUGMpBZLpaXoptD5sBWWWZdjgDrrwIbbWq8KxqdkJQbmWU6DesSHDRnoYjaHgXU944Q/02sILCdeIrK/PZHqb1LhcSvN6nhr/YuZybtHMhitfcV+q4ULdjO3TZ0CwtofxNgtKy0z/kzPlrJjSKQyR/oGBdTqLwoBWv5M7An4/oho1b4L0x+gu2gg/mV6T4HJK5dQtyUDzIBUhxfY8bpGOYvkfo3t0ksmG4acz9QJyqcDWwKOjYDtjDwrTz3OQ3OMsZe3GEQ19KHURtuMAsuy97OTzkpMnBrsC8jr2carFvkqs0Y33HGHMHyTbC7YDm5Vsd+BZUIoas5mIiWPUsAxHZ6e3rbbipZflMaAYrigtjfMr0+JMz0qn2AADshftyWH2YERoTT4f67ghSXth68jTZfZyEZ4bBvgo+h/tNWlfzVwgjDTfuEe6xvhzNe4URmp8J2KnxfvspQcRpF9viYYbwf2qkupDhAiPB2XEF5YX6gJqzTCLW/KGN/sCzh0xUP1WTroYsrIUJ/Mwxi/MYPjzAG8DhZNMP/MBw0rhhSt9hx7f8iKgPchSVXEk1jGCzq0vF47tCTFGILFlWa+b4FfEoLrMt6FBK6NKs44+rc78jmgE7fyuKRAS6TtJM8MfSQ0BrODb+W9mEmOqkgTFZWdXcy9YjCCLY1XE2NghV2+HvOnYYsjFh8X25QJJnn3G3JFv3plL0h1IaDVM++QwdqTN9fVD6myV3HOqfUVr0uSK/x6R34xMWDnpYtmM31i2O09aFpm1+v7SXi5va1wc1bgMr0z+CZVIrYg2WsObb8j/I4QKag/VHKIL0uh+vl3k4diQdUgK5OCwkMNswEd/Cj5ZobjWUWVp57tmFL3KMUAHXHs2u/ppJe8Exq7Z/OD4icEULC4A3LgBiZdwPtslgwZKjE2k+HuY/bcQalvgkzthgPUD18YwA+JsSBjt4Kie5j3vgMSwuLCqbKVGfiobimvXFFlWyH1YDQuAITt43hv4K9zIktCZtcQZVJsLD1qoKrZjb3eI+BxYIQNqKN5f8esUE4QdamfUZwLAEOpKKg7q8y9FCm8I361uViycyCX8UhJggyEWLhrnSqQ+jJ/dySd+u6CbimALEYV8+Z+XIT9ZYEf+l7iJEoVxIeKMX8wvhKKVeSgsfo4gRjjNbXfZl8zX+V8mlCTL42h4pFJuSDYQbOP4IEwDkhm0U4CiI30x5PlSM+qE4AWC2CStLSvsObBc7wff1zWNdkAjzKvh03fe/NTVaBFo5da3Mz5i3ppXGIPVphrUIu98U62QNTfberbnpekvG5HP/glYaXO1NqOfjeTt4gUD1Ue+d0OjqGmil1Wot7ueZX48je6PPbGtP1EgCILadHi5Y3XaHGhIy4jUhhIh0TOl4mYkeqyfiTUliyB8Ua+1uMmsxzYkMAAzEfAcoAAAABFWElGXwAAAElJKgAIAAAAAQBphwQAAQAAABoAAAAAAAAAAQCGkgcAMgAAACwAAAAAAAAAQVNDSUkAAAAxLjcyLjEtMjNKLUlBTkxVTzVVT0FTQTNSU0U1UFhCVDRQNkdFLjAuMi01AA==',
 };
 
 async function connect(
@@ -79,18 +111,23 @@ async function connect(
     mobileWallets?: WalletConnectMobileWallet[]
 ) {
     let modal: WalletConnectModal | undefined;
-    const { mobile, explorer } = mobileWallets?.reduce<{ mobile: MobileWallet[]; explorer: string[] }>(
-        (acc, cur) => {
-            if (typeof cur === 'string') {
-                acc.explorer.push(cur);
-            } else {
-                acc.mobile.push(cur);
-            }
 
-            return acc;
-        },
-        { mobile: [], explorer: [] }
-    ) ?? {};
+    const wallets: MobileWallet[] = [];
+    const explorerIds: string[] = [];
+    const walletImages: Record<string, string> = {};
+    mobileWallets?.forEach(w => {
+        if (w.type === 'explorerId') {
+            explorerIds.push(w.value);
+        } else {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { type: _, iconUrl, ...mw } = w;
+            wallets.push(mw);
+            if (iconUrl !== undefined) {
+                walletImages[mw.id] = iconUrl;
+            }
+        }
+    });
+
     try {
         const { uri, approval } = await client.connect({
             requiredNamespaces: {
@@ -101,10 +138,11 @@ async function connect(
             modal = new WalletConnectModal({
                 projectId: CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
                 chains: scope.chains,
-                mobileWallets: mobile,
+                mobileWallets: wallets,
                 desktopWallets: [],
-                explorerRecommendedWalletIds: explorer,
+                explorerRecommendedWalletIds: explorerIds,
                 explorerExcludedWalletIds: 'ALL',
+                walletImages
             });
             // Open modal as we're not connecting to an existing pairing.
             modal.openModal({ uri });
@@ -476,7 +514,7 @@ export class WalletConnectConnector implements WalletConnector {
      * @param events - The events to request permission to read from the wallet
      * @param mobileWallets - The (mobile) wallets to be selectable from the walletconnect modal
      *
-     * @returns the {@linkcode WalletConnectConnection}, or `undefined` if rejected from the wallet. 
+     * @returns the {@linkcode WalletConnectConnection}, or `undefined` if rejected from the wallet.
      */
     async connectWithScope(
         methods: WalletConnectMethods[],
@@ -515,7 +553,7 @@ export class WalletConnectConnector implements WalletConnector {
                 WalletConnectMethods.RequestVerifiablePresentation,
             ],
             [WalletConnectEvents.AccountsChanged, WalletConnectEvents.ChainChanged],
-            [cryptoXWallet, concordiumWallet]
+            [cryptoXWalletMainnet, concordiumWalletMainnet]
         );
     }
 

--- a/samples/contractupdate/src/config.ts
+++ b/samples/contractupdate/src/config.ts
@@ -1,7 +1,10 @@
 import {
     BrowserWalletConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
+    WalletConnectConnectionScope,
     WalletConnectConnector,
+    WalletConnectEvent,
+    WalletConnectMethod,
     ephemeralConnectorType,
 } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
@@ -16,5 +19,12 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
     },
 };
 
+const WALLET_CONNECT_SCOPE: WalletConnectConnectionScope = {
+    methods: [WalletConnectMethod.SignAndSendTransaction],
+    events: [WalletConnectEvent.AccountsChanged, WalletConnectEvent.ChainChanged],
+};
+
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
-export const WALLET_CONNECT = ephemeralConnectorType(WalletConnectConnector.create.bind(this, WALLET_CONNECT_OPTS));
+export const WALLET_CONNECT = ephemeralConnectorType((delegate, network) =>
+    WalletConnectConnector.create(WALLET_CONNECT_OPTS, delegate, network, WALLET_CONNECT_SCOPE)
+);

--- a/samples/contractupdate/src/config.ts
+++ b/samples/contractupdate/src/config.ts
@@ -1,10 +1,10 @@
 import {
     BrowserWalletConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
-    WalletConnectConnectionScope,
     WalletConnectConnector,
     WalletConnectEvent,
     WalletConnectMethod,
+    WalletConnectNamespaceConfig,
     ephemeralConnectorType,
 } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
@@ -19,12 +19,12 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
     },
 };
 
-const WALLET_CONNECT_SCOPE: WalletConnectConnectionScope = {
+const WALLET_CONNECT_NS_CONFIG: WalletConnectNamespaceConfig = {
     methods: [WalletConnectMethod.SignAndSendTransaction],
     events: [WalletConnectEvent.AccountsChanged, WalletConnectEvent.ChainChanged],
 };
 
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
 export const WALLET_CONNECT = ephemeralConnectorType((delegate, network) =>
-    WalletConnectConnector.create(WALLET_CONNECT_OPTS, delegate, network, WALLET_CONNECT_SCOPE)
+    WalletConnectConnector.create(WALLET_CONNECT_OPTS, delegate, network, WALLET_CONNECT_NS_CONFIG)
 );

--- a/samples/proofs/src/config.ts
+++ b/samples/proofs/src/config.ts
@@ -1,10 +1,10 @@
 import {
     BrowserWalletConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
-    WalletConnectConnectionScope,
     WalletConnectConnector,
     WalletConnectEvent,
     WalletConnectMethod,
+    WalletConnectNamespaceConfig,
     ephemeralConnectorType,
 } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
@@ -19,7 +19,7 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
     },
 };
 
-const WALLET_CONNECT_SCOPE: WalletConnectConnectionScope = {
+const WALLET_CONNECT_SCOPE: WalletConnectNamespaceConfig = {
     methods: [WalletConnectMethod.RequestVerifiablePresentation],
     events: [WalletConnectEvent.AccountsChanged, WalletConnectEvent.ChainChanged],
 };

--- a/samples/proofs/src/config.ts
+++ b/samples/proofs/src/config.ts
@@ -1,7 +1,10 @@
 import {
     BrowserWalletConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
+    WalletConnectConnectionScope,
     WalletConnectConnector,
+    WalletConnectEvent,
+    WalletConnectMethod,
     ephemeralConnectorType,
 } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
@@ -16,5 +19,12 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
     },
 };
 
+const WALLET_CONNECT_SCOPE: WalletConnectConnectionScope = {
+    methods: [WalletConnectMethod.RequestVerifiablePresentation],
+    events: [WalletConnectEvent.AccountsChanged, WalletConnectEvent.ChainChanged],
+};
+
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
-export const WALLET_CONNECT = ephemeralConnectorType(WalletConnectConnector.create.bind(this, WALLET_CONNECT_OPTS));
+export const WALLET_CONNECT = ephemeralConnectorType((delegate, network) =>
+    WalletConnectConnector.create(WALLET_CONNECT_OPTS, delegate, network, WALLET_CONNECT_SCOPE)
+);

--- a/samples/sign-message/src/config.ts
+++ b/samples/sign-message/src/config.ts
@@ -1,10 +1,10 @@
 import {
     BrowserWalletConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
-    WalletConnectConnectionScope,
     WalletConnectConnector,
     WalletConnectEvent,
     WalletConnectMethod,
+    WalletConnectNamespaceConfig,
     ephemeralConnectorType,
 } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
@@ -19,7 +19,7 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
     },
 };
 
-const WALLET_CONNECT_SCOPE: WalletConnectConnectionScope = {
+const WALLET_CONNECT_SCOPE: WalletConnectNamespaceConfig = {
     methods: [WalletConnectMethod.SignMessage],
     events: [WalletConnectEvent.AccountsChanged, WalletConnectEvent.ChainChanged],
 };

--- a/samples/sign-message/src/config.ts
+++ b/samples/sign-message/src/config.ts
@@ -1,7 +1,10 @@
 import {
     BrowserWalletConnector,
     CONCORDIUM_WALLET_CONNECT_PROJECT_ID,
+    WalletConnectConnectionScope,
     WalletConnectConnector,
+    WalletConnectEvent,
+    WalletConnectMethod,
     ephemeralConnectorType,
 } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
@@ -16,5 +19,12 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
     },
 };
 
+const WALLET_CONNECT_SCOPE: WalletConnectConnectionScope = {
+    methods: [WalletConnectMethod.SignMessage],
+    events: [WalletConnectEvent.AccountsChanged, WalletConnectEvent.ChainChanged],
+};
+
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
-export const WALLET_CONNECT = ephemeralConnectorType(WalletConnectConnector.create.bind(this, WALLET_CONNECT_OPTS));
+export const WALLET_CONNECT = ephemeralConnectorType((delegate, network) =>
+    WalletConnectConnector.create(WALLET_CONNECT_OPTS, delegate, network, WALLET_CONNECT_SCOPE)
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,7 +1969,8 @@ __metadata:
     "@jest/types": ^29.6.3
     "@tsconfig/recommended": ^1.0.1
     "@types/jest": ^29.5.12
-    "@walletconnect/qrcode-modal": ^1.8.0
+    "@walletconnect/modal": ^2.6.2
+    "@walletconnect/modal-core": ^2.6.2
     "@walletconnect/sign-client": ^2.1.4
     "@walletconnect/types": ^2.1.4
     jest: ^29.7.0
@@ -2933,6 +2934,107 @@ __metadata:
   version: 2.0.4
   resolution: "@leichtgewicht/ip-codec@npm:2.0.4"
   checksum: 468de1f04d33de6d300892683d7c8aecbf96d1e2c5fe084f95f816e50a054d45b7c1ebfb141a1447d844b86a948733f6eebd92234da8581c84a1ad4de2946a2d
+  languageName: node
+  linkType: hard
+
+"@lit-labs/ssr-dom-shim@npm:^1.0.0, @lit-labs/ssr-dom-shim@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.2.0"
+  checksum: 704621c28df8d651e54a1b93f6ede8103db2dd3e7a1f02463fe5492bd28aa22de813314c7833260204fed5c8491a6bbd763f6051abc25690df537d812a508c35
+  languageName: node
+  linkType: hard
+
+"@lit/reactive-element@npm:^1.3.0, @lit/reactive-element@npm:^1.6.0":
+  version: 1.6.3
+  resolution: "@lit/reactive-element@npm:1.6.3"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": ^1.0.0
+  checksum: 79b58631c38effeabad090070324431da8a22cf0ff665f5e4de35e4d791f984742b3d340c9c7fce996d1124a8da95febc582471b4c237236c770b1300b56ef6e
+  languageName: node
+  linkType: hard
+
+"@motionone/animation@npm:^10.15.1, @motionone/animation@npm:^10.17.0":
+  version: 10.17.0
+  resolution: "@motionone/animation@npm:10.17.0"
+  dependencies:
+    "@motionone/easing": ^10.17.0
+    "@motionone/types": ^10.17.0
+    "@motionone/utils": ^10.17.0
+    tslib: ^2.3.1
+  checksum: 8cab13cde7ccbe29bcaff1cb43ba39acdc51d9be4726628f4d0ba27898c59456887fd9ec56aceaa3d5b82993efbdfa9a7b9e99d4b96bc458f486208394027093
+  languageName: node
+  linkType: hard
+
+"@motionone/dom@npm:^10.16.2, @motionone/dom@npm:^10.16.4":
+  version: 10.17.0
+  resolution: "@motionone/dom@npm:10.17.0"
+  dependencies:
+    "@motionone/animation": ^10.17.0
+    "@motionone/generators": ^10.17.0
+    "@motionone/types": ^10.17.0
+    "@motionone/utils": ^10.17.0
+    hey-listen: ^1.0.8
+    tslib: ^2.3.1
+  checksum: 6415f17032136218dfa88b9b00fbab738e514544129edf6f5c01dbdacefe9be48efd2d06f3d0cb7f2f5d2d2d79c94362effc7d034332406fd4dec6a710e603a2
+  languageName: node
+  linkType: hard
+
+"@motionone/easing@npm:^10.17.0":
+  version: 10.17.0
+  resolution: "@motionone/easing@npm:10.17.0"
+  dependencies:
+    "@motionone/utils": ^10.17.0
+    tslib: ^2.3.1
+  checksum: 2870d9e94645cf4ed3a27309a858dccee26615291ec46b56e993ef3ac9f059a659b02a2115ed61d27250fc8800acc9640f0319aeb402de7fa0e15dffbebeb548
+  languageName: node
+  linkType: hard
+
+"@motionone/generators@npm:^10.17.0":
+  version: 10.17.0
+  resolution: "@motionone/generators@npm:10.17.0"
+  dependencies:
+    "@motionone/types": ^10.17.0
+    "@motionone/utils": ^10.17.0
+    tslib: ^2.3.1
+  checksum: 6d048a0362692db3f450b97c1679a8d0265bff93106412bdcc33b9c48b9362a3e97f672f29a2932d5e393330750fdd55921c1c9b2bf20690922a37a0164e649f
+  languageName: node
+  linkType: hard
+
+"@motionone/svelte@npm:^10.16.2":
+  version: 10.16.4
+  resolution: "@motionone/svelte@npm:10.16.4"
+  dependencies:
+    "@motionone/dom": ^10.16.4
+    tslib: ^2.3.1
+  checksum: 699e20955ea832bcf32d410ae9f88edf61a5c2cf2b56527119ab1df6fecbf2632b62d541743d0f6d278fd700a15a20b9eb7c8aa5266e7aed5e113b8f8f75b863
+  languageName: node
+  linkType: hard
+
+"@motionone/types@npm:^10.15.1, @motionone/types@npm:^10.17.0":
+  version: 10.17.0
+  resolution: "@motionone/types@npm:10.17.0"
+  checksum: 3996c84e1578b17146c14bd581ab682b7b2a06ca7fd5a7dc378a0f3b10539256d7b803a7df748f0c60d6df6b33950269a27ba2bb1839de779196bd024bee4b87
+  languageName: node
+  linkType: hard
+
+"@motionone/utils@npm:^10.15.1, @motionone/utils@npm:^10.17.0":
+  version: 10.17.0
+  resolution: "@motionone/utils@npm:10.17.0"
+  dependencies:
+    "@motionone/types": ^10.17.0
+    hey-listen: ^1.0.8
+    tslib: ^2.3.1
+  checksum: 408e278c9051a221e528bb9ca0a773018b9953ecd53bb88715421afc009f4647417b0d9f163c8195467badd934f39ade24f57e007416988e4291242e749ea43d
+  languageName: node
+  linkType: hard
+
+"@motionone/vue@npm:^10.16.2":
+  version: 10.16.4
+  resolution: "@motionone/vue@npm:10.16.4"
+  dependencies:
+    "@motionone/dom": ^10.16.4
+    tslib: ^2.3.1
+  checksum: 746e38d0ee831829bfac2ce471f3d98a9e37bd8cbdf2706fa3becce69c17f51180a1ee47582d97758d68aafdfc9a187ab47ff216c77254ac994287dabcf266c1
   languageName: node
   linkType: hard
 
@@ -4569,19 +4671,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/browser-utils@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "@walletconnect/browser-utils@npm:1.8.0"
-  dependencies:
-    "@walletconnect/safe-json": 1.0.0
-    "@walletconnect/types": ^1.8.0
-    "@walletconnect/window-getters": 1.0.0
-    "@walletconnect/window-metadata": 1.0.0
-    detect-browser: 5.2.0
-  checksum: cf4b55c9e8d53b1ffa99322ebcdfce7ad8df8e3ee90f57252da0b3882d3bfb592414cad09900c20619216c6a42d1184ad03728e6514e95a34467a8821aa5aef8
-  languageName: node
-  linkType: hard
-
 "@walletconnect/core@npm:2.7.7":
   version: 2.7.7
   resolution: "@walletconnect/core@npm:2.7.7"
@@ -4709,24 +4798,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/mobile-registry@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@walletconnect/mobile-registry@npm:1.4.0"
-  checksum: 06f18842e68f88e71e87f36daea143684afc49551974cf359fb55cc731e9b4fc0bce762d87b79b268e529def889e82fc2fbc2bc12d6a28a04ed0d6a060188020
+"@walletconnect/modal-core@npm:2.6.2, @walletconnect/modal-core@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "@walletconnect/modal-core@npm:2.6.2"
+  dependencies:
+    valtio: 1.11.2
+  checksum: 94daceba50c323b06ecbeac2968d9f0972f327359c6118887c6526cd64006249b12f64322d71bc6c4a2b928436ecc89cf3d3af706511fcdc264c1f4b34a2dd5d
   languageName: node
   linkType: hard
 
-"@walletconnect/qrcode-modal@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "@walletconnect/qrcode-modal@npm:1.8.0"
+"@walletconnect/modal-ui@npm:2.6.2":
+  version: 2.6.2
+  resolution: "@walletconnect/modal-ui@npm:2.6.2"
   dependencies:
-    "@walletconnect/browser-utils": ^1.8.0
-    "@walletconnect/mobile-registry": ^1.4.0
-    "@walletconnect/types": ^1.8.0
-    copy-to-clipboard: ^3.3.1
-    preact: 10.4.1
-    qrcode: 1.4.4
-  checksum: 0abae2268579f55da87ed766fee32d428f951f18ab0a4addbfe8cbcbad1ce3a5642cc26ceb80654b158e537000ee5006b14eff43515619bc17af8c5da51adc55
+    "@walletconnect/modal-core": 2.6.2
+    lit: 2.8.0
+    motion: 10.16.2
+    qrcode: 1.5.3
+  checksum: cd1ec0205eb491e529670599d3dd26f6782d7c5a99d5594bf6949a8c760c1c5f4eb6ed72b8662450774fe4e2dd47678f2c05145c8f2494bd7153446ddf4bd7ed
+  languageName: node
+  linkType: hard
+
+"@walletconnect/modal@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "@walletconnect/modal@npm:2.6.2"
+  dependencies:
+    "@walletconnect/modal-core": 2.6.2
+    "@walletconnect/modal-ui": 2.6.2
+  checksum: 68b354d49960b96d22de0e47a3801df27c01a3e96ec5fbde3ca6df1344ca2b20668b0c4d58fe1803f5670ac7b7b4c6f5b7b405e354f5f9eaff5cca147c13de9c
   languageName: node
   linkType: hard
 
@@ -4751,13 +4850,6 @@ __metadata:
     tslib: 1.14.1
     uint8arrays: ^3.0.0
   checksum: 35b3229d7b57e74fdb8fe6827d8dd8291dc60bacda880a57b2acb47a34d38f12be46c971c9eff361eb4073e896648b550de7a7a3852ef3752f9619c08dfba891
-  languageName: node
-  linkType: hard
-
-"@walletconnect/safe-json@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@walletconnect/safe-json@npm:1.0.0"
-  checksum: a8ee161cad37242983522d19ace57c2d2725b5b1cf5fd4d61e3e5f4190a2b369acc4cd0fa40774b50cf4aa322f477e31b7841a6b8f0d84a3af12da8c4344e9b7
   languageName: node
   linkType: hard
 
@@ -4810,13 +4902,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "@walletconnect/types@npm:1.8.0"
-  checksum: 194d615888068030183489222641332987846aa5c6bcf0a62fa60ca7a282b9f94932c49fcd2b293a859e98624fe3e7a2d3c5fb66545fe30d3391e7ac91a99e34
-  languageName: node
-  linkType: hard
-
 "@walletconnect/utils@npm:2.7.7":
   version: 2.7.7
   resolution: "@walletconnect/utils@npm:2.7.7"
@@ -4839,28 +4924,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/window-getters@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@walletconnect/window-getters@npm:1.0.0"
-  checksum: 192af7acb2051d304addb2e5a3f121fedd8c83ba6750018e3b0da5757bad525336bc5d9cb571f63b09828658764151da181337ec0e898811ad7f506910bd3b5f
-  languageName: node
-  linkType: hard
-
-"@walletconnect/window-getters@npm:^1.0.0, @walletconnect/window-getters@npm:^1.0.1":
+"@walletconnect/window-getters@npm:^1.0.1":
   version: 1.0.1
   resolution: "@walletconnect/window-getters@npm:1.0.1"
   dependencies:
     tslib: 1.14.1
   checksum: fae312c4e1be5574d97f071de58e6aa0d0296869761499caf9d4a9a5fd2643458af32233a2120521b00873a599ff88457d405bd82ced5fb5bd6dc3191c07a3e5
-  languageName: node
-  linkType: hard
-
-"@walletconnect/window-metadata@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@walletconnect/window-metadata@npm:1.0.0"
-  dependencies:
-    "@walletconnect/window-getters": ^1.0.0
-  checksum: eec506ff6d35ae6e88db1e38b6f514f6cbf1a45b979878e5e50819d229b616fc645a2b0816145b61acda2701042160a4e0685f080927b87461853a62a887a9e9
   languageName: node
   linkType: hard
 
@@ -5255,13 +5324,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "ansi-regex@npm:4.1.1"
-  checksum: b1a6ee44cb6ecdabaa770b2ed500542714d4395d71c7e5c25baa631f680fb2ad322eb9ba697548d498a6fd366949fc8b5bfcf48d49a32803611f648005b01888
-  languageName: node
-  linkType: hard
-
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -5276,7 +5338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
+"ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
@@ -6008,44 +6070,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-alloc-unsafe@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "buffer-alloc-unsafe@npm:1.1.0"
-  checksum: c5e18bf51f67754ec843c9af3d4c005051aac5008a3992938dda1344e5cfec77c4b02b4ca303644d1e9a6e281765155ce6356d85c6f5ccc5cd21afc868def396
-  languageName: node
-  linkType: hard
-
-"buffer-alloc@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "buffer-alloc@npm:1.2.0"
-  dependencies:
-    buffer-alloc-unsafe: ^1.1.0
-    buffer-fill: ^1.0.0
-  checksum: 560cd27f3cbe73c614867da373407d4506309c62fe18de45a1ce191f3785ec6ca2488d802ff82065798542422980ca25f903db078c57822218182c37c3576df5
-  languageName: node
-  linkType: hard
-
-"buffer-fill@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "buffer-fill@npm:1.0.0"
-  checksum: c29b4723ddeab01e74b5d3b982a0c6828f2ded49cef049ddca3dac661c874ecdbcecb5dd8380cf0f4adbeb8cff90a7de724126750a1f1e5ebd4eb6c59a1315b1
-  languageName: node
-  linkType: hard
-
-"buffer-from@npm:^1.0.0, buffer-from@npm:^1.1.1":
+"buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^5.4.3":
-  version: 5.7.1
-  resolution: "buffer@npm:5.7.1"
-  dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.1.13
-  checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
   languageName: node
   linkType: hard
 
@@ -6345,14 +6373,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "cliui@npm:5.0.0"
+"cliui@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "cliui@npm:6.0.0"
   dependencies:
-    string-width: ^3.1.0
-    strip-ansi: ^5.2.0
-    wrap-ansi: ^5.1.0
-  checksum: 0bb8779efe299b8f3002a73619eaa8add4081eb8d1c17bc4fedc6240557fb4eacdc08fe87c39b002eacb6cfc117ce736b362dbfd8bf28d90da800e010ee97df4
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.0
+    wrap-ansi: ^6.2.0
+  checksum: 4fcfd26d292c9f00238117f39fc797608292ae36bac2168cfee4c85923817d0607fe21b3329a8621e01aedf512c99b7eaa60e363a671ffd378df6649fb48ae42
   languageName: node
   linkType: hard
 
@@ -6683,15 +6711,6 @@ __metadata:
   version: 0.5.0
   resolution: "cookie@npm:0.5.0"
   checksum: 1f4bd2ca5765f8c9689a7e8954183f5332139eb72b6ff783d8947032ec1fdf43109852c178e21a953a30c0dd42257828185be01b49d1eb1a67fd054ca588a180
-  languageName: node
-  linkType: hard
-
-"copy-to-clipboard@npm:^3.3.1":
-  version: 3.3.3
-  resolution: "copy-to-clipboard@npm:3.3.3"
-  dependencies:
-    toggle-selection: ^1.0.6
-  checksum: e0a325e39b7615108e6c1c8ac110ae7b829cdc4ee3278b1df6a0e4228c490442cc86444cd643e2da344fbc424b3aab8909e2fec82f8bc75e7e5b190b7c24eecf
   languageName: node
   linkType: hard
 
@@ -7267,13 +7286,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-browser@npm:5.2.0":
-  version: 5.2.0
-  resolution: "detect-browser@npm:5.2.0"
-  checksum: 63b5c38fecc657ff12de01a41e6c8c97b3d610dffa37aef1983ec5bfb4314687d588c0c44c5ee03bd45ef15b7fe465bce9349c373369e6a7405f318e0aae56f9
-  languageName: node
-  linkType: hard
-
 "detect-browser@npm:5.3.0":
   version: 5.3.0
   resolution: "detect-browser@npm:5.3.0"
@@ -7603,13 +7615,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emoji-regex@npm:^7.0.1":
-  version: 7.0.3
-  resolution: "emoji-regex@npm:7.0.3"
-  checksum: 9159b2228b1511f2870ac5920f394c7e041715429a68459ebe531601555f11ea782a8e1718f969df2711d38c66268174407cbca57ce36485544f695c2dfdc96e
-  languageName: node
-  linkType: hard
-
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -7628,6 +7633,13 @@ __metadata:
   version: 3.0.0
   resolution: "emojis-list@npm:3.0.0"
   checksum: ddaaa02542e1e9436c03970eeed445f4ed29a5337dfba0fe0c38dfdd2af5da2429c2a0821304e8a8d1cadf27fdd5b22ff793571fa803ae16852a6975c65e8e70
+  languageName: node
+  linkType: hard
+
+"encode-utf8@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "encode-utf8@npm:1.0.3"
+  checksum: 550224bf2a104b1d355458c8a82e9b4ea07f9fc78387bc3a49c151b940ad26473de8dc9e121eefc4e84561cb0b46de1e4cd2bc766f72ee145e9ea9541482817f
   languageName: node
   linkType: hard
 
@@ -9047,6 +9059,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hey-listen@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "hey-listen@npm:1.0.8"
+  checksum: 6bad60b367688f5348e25e7ca3276a74b59ac5a09b0455e6ff8ab7d4a9e38cd2116c708a7dcd8a954d27253ce1d8717ec891d175723ea739885b828cf44e4072
+  languageName: node
+  linkType: hard
+
 "hoopy@npm:^0.1.4":
   version: 0.1.4
   resolution: "hoopy@npm:0.1.4"
@@ -9315,7 +9334,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
+"ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -9548,13 +9567,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-fullwidth-code-point@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-fullwidth-code-point@npm:2.0.0"
-  checksum: eef9c6e15f68085fec19ff6a978a6f1b8f48018fd1265035552078ee945573594933b09bbd6f562553e2a241561439f1ef5339276eba68d272001343084cfab8
-  languageName: node
-  linkType: hard
-
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
@@ -9784,7 +9796,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:^2.0.1, isarray@npm:^2.0.5":
+"isarray@npm:^2.0.5":
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: bd5bbe4104438c4196ba58a54650116007fa0262eccef13a4c55b2e09a5b36b59f1e75b9fcc49883dd9d4953892e6fc007eef9e9155648ceea036e184b0f930a
@@ -11299,6 +11311,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lit-element@npm:^3.3.0":
+  version: 3.3.3
+  resolution: "lit-element@npm:3.3.3"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": ^1.1.0
+    "@lit/reactive-element": ^1.3.0
+    lit-html: ^2.8.0
+  checksum: 29a596fa556e231cce7246ca3e5687ad238f299b0cb374a0934d5e6fe9adf1436e031d4fbd21b280aabfc0e21a66e6c4b52da558a908df2566d09d960f3ca93d
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "lit-html@npm:2.8.0"
+  dependencies:
+    "@types/trusted-types": ^2.0.2
+  checksum: 2d70df07248bcb2f502a3afb1e91d260735024fa669669ffb1417575aa39c3092779725ac1b90f5f39e4ce78c63f431f51176bc67f532389f0285a6991573255
+  languageName: node
+  linkType: hard
+
+"lit@npm:2.8.0":
+  version: 2.8.0
+  resolution: "lit@npm:2.8.0"
+  dependencies:
+    "@lit/reactive-element": ^1.6.0
+    lit-element: ^3.3.0
+    lit-html: ^2.8.0
+  checksum: 2480e733f7d022d3ecba91abc58a20968f0ca8f5fa30b3341ecf4bcf4845e674ad27b721a5ae53529cafc6ca603c015b80d0979ceb7a711e268ef20bb6bc7527
+  languageName: node
+  linkType: hard
+
 "loader-runner@npm:^4.2.0":
   version: 4.3.0
   resolution: "loader-runner@npm:4.3.0"
@@ -11790,6 +11833,20 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
+  languageName: node
+  linkType: hard
+
+"motion@npm:10.16.2":
+  version: 10.16.2
+  resolution: "motion@npm:10.16.2"
+  dependencies:
+    "@motionone/animation": ^10.15.1
+    "@motionone/dom": ^10.16.2
+    "@motionone/svelte": ^10.16.2
+    "@motionone/types": ^10.15.1
+    "@motionone/utils": ^10.15.1
+    "@motionone/vue": ^10.16.2
+  checksum: 0b91256808c2374d8b7f4ac5e7ed513f2ca8df2b7d1be4fbc00ec5baece5162ada648aedaa5bc1d60be9ad2e6c9bc1d3bb160333051c20ab79e241b8e02e3c92
   languageName: node
   linkType: hard
 
@@ -12533,10 +12590,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pngjs@npm:^3.3.0":
-  version: 3.4.0
-  resolution: "pngjs@npm:3.4.0"
-  checksum: 8bd40bd698abd16b72c97b85cb858c80894fbedc76277ce72a784aa441e14795d45d9856e97333ca469b34b67528860ffc8a7317ca6beea349b645366df00bcd
+"pngjs@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pngjs@npm:5.0.0"
+  checksum: 04e912cc45fb9601564e2284efaf0c5d20d131d9b596244f8a6789fc6cdb6b18d2975a6bbf7a001858d7e159d5c5c5dd7b11592e97629b7137f7f5cef05904c8
   languageName: node
   linkType: hard
 
@@ -13381,13 +13438,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"preact@npm:10.4.1":
-  version: 10.4.1
-  resolution: "preact@npm:10.4.1"
-  checksum: e8c5eae6dca469226177394cf49994d6beab5b9b10d31e000d8b16d9b00bfa52cdd10b41331759d68646e7b8f601430d78eb025f9026263adc90150699800ed3
-  languageName: node
-  linkType: hard
-
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -13576,6 +13626,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-compare@npm:2.5.1":
+  version: 2.5.1
+  resolution: "proxy-compare@npm:2.5.1"
+  checksum: c7cc151ac255150bcb24becde6495b3e399416c31991af377ce082255b51f07eaeb5d861bf8bf482703e92f88b90a5892ad57d3153ea29450d03ef921683d9fa
+  languageName: node
+  linkType: hard
+
 "psl@npm:^1.1.33":
   version: 1.9.0
   resolution: "psl@npm:1.9.0"
@@ -13604,20 +13661,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qrcode@npm:1.4.4":
-  version: 1.4.4
-  resolution: "qrcode@npm:1.4.4"
+"qrcode@npm:1.5.3":
+  version: 1.5.3
+  resolution: "qrcode@npm:1.5.3"
   dependencies:
-    buffer: ^5.4.3
-    buffer-alloc: ^1.2.0
-    buffer-from: ^1.1.1
     dijkstrajs: ^1.0.1
-    isarray: ^2.0.1
-    pngjs: ^3.3.0
-    yargs: ^13.2.4
+    encode-utf8: ^1.0.3
+    pngjs: ^5.0.0
+    yargs: ^15.3.1
   bin:
-    qrcode: ./bin/qrcode
-  checksum: 8c1a7ee3092c0ed60f0413594af879ac6dffb897d4921144a8e7ae3dce40c04ba6457ab21664ca43934ba3fe19cced85abaf0b87b07916239d7254d4bb4fcf13
+    qrcode: bin/qrcode
+  checksum: 9a8a20a0a9cb1d15de8e7b3ffa214e8b6d2a8b07655f25bd1b1d77f4681488f84d7bae569870c0652872d829d5f8ac4922c27a6bd14c13f0e197bf07b28dead7
   languageName: node
   linkType: hard
 
@@ -15053,17 +15107,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^3.0.0, string-width@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "string-width@npm:3.1.0"
-  dependencies:
-    emoji-regex: ^7.0.1
-    is-fullwidth-code-point: ^2.0.0
-    strip-ansi: ^5.1.0
-  checksum: 57f7ca73d201682816d573dc68bd4bb8e1dff8dc9fcf10470fdfc3474135c97175fec12ea6a159e67339b41e86963112355b64529489af6e7e70f94a7caf08b2
-  languageName: node
-  linkType: hard
-
 "string-width@npm:^5.0.0":
   version: 5.1.2
   resolution: "string-width@npm:5.1.2"
@@ -15150,15 +15193,6 @@ __metadata:
     is-obj: ^1.0.1
     is-regexp: ^1.0.0
   checksum: 6827a3f35975cfa8572e8cd3ed4f7b262def260af18655c6fde549334acdac49ddba69f3c861ea5a6e9c5a4990fe4ae870b9c0e6c31019430504c94a83b7a154
-  languageName: node
-  linkType: hard
-
-"strip-ansi@npm:^5.0.0, strip-ansi@npm:^5.1.0, strip-ansi@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "strip-ansi@npm:5.2.0"
-  dependencies:
-    ansi-regex: ^4.1.0
-  checksum: bdb5f76ade97062bd88e7723aa019adbfacdcba42223b19ccb528ffb9fb0b89a5be442c663c4a3fb25268eaa3f6ea19c7c3fbae830bd1562d55adccae1fcec46
   languageName: node
   linkType: hard
 
@@ -15584,13 +15618,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toggle-selection@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "toggle-selection@npm:1.0.6"
-  checksum: a90dc80ed1e7b18db8f4e16e86a5574f87632dc729cfc07d9ea3ced50021ad42bb4e08f22c0913e0b98e3837b0b717e0a51613c65f30418e21eb99da6556a74c
-  languageName: node
-  linkType: hard
-
 "toidentifier@npm:1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
@@ -15745,6 +15772,13 @@ __metadata:
   version: 2.5.2
   resolution: "tslib@npm:2.5.2"
   checksum: 4d3c1e238b94127ed0e88aa0380db3c2ddae581dc0f4bae5a982345e9f50ee5eda90835b8bfba99b02df10a5734470be197158c36f9129ac49fdc14a6a9da222
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.3.1":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
   languageName: node
   linkType: hard
 
@@ -16046,6 +16080,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-sync-external-store@npm:1.2.0":
+  version: 1.2.0
+  resolution: "use-sync-external-store@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 5c639e0f8da3521d605f59ce5be9e094ca772bd44a4ce7322b055a6f58eeed8dda3c94cabd90c7a41fb6fa852210092008afe48f7038792fd47501f33299116a
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -16114,6 +16157,24 @@ __metadata:
     "@types/istanbul-lib-coverage": ^2.0.1
     convert-source-map: ^2.0.0
   checksum: 31ef98c6a31b1dab6be024cf914f235408cd4c0dc56a5c744a5eea1a9e019ba279e1b6f90d695b78c3186feed391ed492380ccf095009e2eb91f3d058f0b4491
+  languageName: node
+  linkType: hard
+
+"valtio@npm:1.11.2":
+  version: 1.11.2
+  resolution: "valtio@npm:1.11.2"
+  dependencies:
+    proxy-compare: 2.5.1
+    use-sync-external-store: 1.2.0
+  peerDependencies:
+    "@types/react": ">=16.8"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: cce2d9212aac9fc4bdeba2d381188cc831cfe8d2d03039024cfcd58ba1801f2a5b14d01c2bb21a2c9f12046d2ede64f1dd887175185f39bee553677a35592c30
   languageName: node
   linkType: hard
 
@@ -16697,17 +16758,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "wrap-ansi@npm:5.1.0"
-  dependencies:
-    ansi-styles: ^3.2.0
-    string-width: ^3.0.0
-    strip-ansi: ^5.0.0
-  checksum: 9b48c862220e541eb0daa22661b38b947973fc57054e91be5b0f2dcc77741a6875ccab4ebe970a394b4682c8dfc17e888266a105fb8b0a9b23c19245e781ceae
-  languageName: node
-  linkType: hard
-
 "wrap-ansi@npm:^6.2.0":
   version: 6.2.0
   resolution: "wrap-ansi@npm:6.2.0"
@@ -16845,13 +16895,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^13.1.2":
-  version: 13.1.2
-  resolution: "yargs-parser@npm:13.1.2"
+"yargs-parser@npm:^18.1.2":
+  version: 18.1.3
+  resolution: "yargs-parser@npm:18.1.3"
   dependencies:
     camelcase: ^5.0.0
     decamelize: ^1.2.0
-  checksum: c8bb6f44d39a4acd94462e96d4e85469df865de6f4326e0ab1ac23ae4a835e5dd2ddfe588317ebf80c3a7e37e741bd5cb0dc8d92bcc5812baefb7df7c885e86b
+  checksum: 60e8c7d1b85814594d3719300ecad4e6ae3796748b0926137bfec1f3042581b8646d67e83c6fc80a692ef08b8390f21ddcacb9464476c39bbdf52e34961dd4d9
   languageName: node
   linkType: hard
 
@@ -16869,21 +16919,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^13.2.4":
-  version: 13.3.2
-  resolution: "yargs@npm:13.3.2"
+"yargs@npm:^15.3.1":
+  version: 15.4.1
+  resolution: "yargs@npm:15.4.1"
   dependencies:
-    cliui: ^5.0.0
-    find-up: ^3.0.0
+    cliui: ^6.0.0
+    decamelize: ^1.2.0
+    find-up: ^4.1.0
     get-caller-file: ^2.0.1
     require-directory: ^2.1.1
     require-main-filename: ^2.0.0
     set-blocking: ^2.0.0
-    string-width: ^3.0.0
+    string-width: ^4.2.0
     which-module: ^2.0.0
     y18n: ^4.0.0
-    yargs-parser: ^13.1.2
-  checksum: 75c13e837eb2bb25717957ba58d277e864efc0cca7f945c98bdf6477e6ec2f9be6afa9ed8a876b251a21423500c148d7b91e88dee7adea6029bdec97af1ef3e8
+    yargs-parser: ^18.1.2
+  checksum: 40b974f508d8aed28598087720e086ecd32a5fd3e945e95ea4457da04ee9bdb8bdd17fd91acff36dc5b7f0595a735929c514c40c402416bbb87c03f6fb782373
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,7 +1942,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/react-components@workspace:packages/react-components"
   dependencies:
-    "@concordium/wallet-connectors": ^0.5.1
+    "@concordium/wallet-connectors": ^0.6.0-alpha.5
     "@tsconfig/recommended": ^1.0.1
     "@types/node": ^18.11.17
     "@types/react": ^18
@@ -1961,7 +1961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/wallet-connectors@^0.5.1, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
+"@concordium/wallet-connectors@^0.6.0-alpha.5, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
   version: 0.0.0-use.local
   resolution: "@concordium/wallet-connectors@workspace:packages/wallet-connectors"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,7 +1942,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/react-components@workspace:packages/react-components"
   dependencies:
-    "@concordium/wallet-connectors": ^0.6.0-alpha.6
+    "@concordium/wallet-connectors": ^0.5.1
     "@tsconfig/recommended": ^1.0.1
     "@types/node": ^18.11.17
     "@types/react": ^18
@@ -1961,7 +1961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/wallet-connectors@^0.6.0-alpha.6, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
+"@concordium/wallet-connectors@^0.5.1, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
   version: 0.0.0-use.local
   resolution: "@concordium/wallet-connectors@workspace:packages/wallet-connectors"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,7 +1942,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/react-components@workspace:packages/react-components"
   dependencies:
-    "@concordium/wallet-connectors": ^0.6.0-alpha.5
+    "@concordium/wallet-connectors": ^0.6.0-alpha.6
     "@tsconfig/recommended": ^1.0.1
     "@types/node": ^18.11.17
     "@types/react": ^18
@@ -1961,7 +1961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/wallet-connectors@^0.6.0-alpha.5, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
+"@concordium/wallet-connectors@^0.6.0-alpha.6, @concordium/wallet-connectors@workspace:packages/wallet-connectors":
   version: 0.0.0-use.local
   resolution: "@concordium/wallet-connectors@workspace:packages/wallet-connectors"
   dependencies:


### PR DESCRIPTION
## Purpose

Deep linking does not work with the deprecated `@walletconnect/qrcode-modal`. This PR aims to update the dependency. Additionally, I've added a method on the wallet connect connector for defining the scope of the connection made to a wallet (`connectWithScope`), as it seems there is not feature parity with regards to the supported wallet connect methods.

This is already used in the published alpha version in the gc voting application (added in https://github.com/Concordium/concordium-governance-committee-voting/pull/115).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
