### PR TITLE
Add entrypoint for binary signing in mobile wallets

### DIFF
--- a/packages/react-components/src/WithWalletConnector.ts
+++ b/packages/react-components/src/WithWalletConnector.ts
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { Network, WalletConnection, WalletConnectionDelegate, WalletConnector } from '@concordium/wallet-connectors';
+import { Network, WalletConnectNamespaceConfig, WalletConnection, WalletConnectionDelegate, WalletConnector } from '@concordium/wallet-connectors';
 import { errorString } from './error';
 
 /**
@@ -13,7 +13,7 @@ export interface ConnectorType {
      *                  This object doubles as the delegate to pass to new connector instances.
      * @param network The network to pass to new connector instances.
      */
-    activate(component: WithWalletConnector, network: Network): Promise<WalletConnector>;
+    activate(component: WithWalletConnector, network: Network, namespaceConfig: WalletConnectNamespaceConfig | undefined): Promise<WalletConnector>;
 
     /**
      * Called from {@link WithWalletConnector} when the connection type is being deactivated,
@@ -43,14 +43,14 @@ export function ephemeralConnectorType(create: (c: WithWalletConnector, n: Netwo
  * Note that only the connector is permanent. Individual connections may still be disconnected by the application.
  * @param create Factory function for creating new connector instances.
  */
-export function persistentConnectorType(create: (c: WithWalletConnector, n: Network) => Promise<WalletConnector>) {
+export function persistentConnectorType(create: (c: WithWalletConnector, n: Network, namespaceConfig: WalletConnectNamespaceConfig) => Promise<WalletConnector>) {
     const connectorPromises = new Map<WithWalletConnector, Map<Network, Promise<WalletConnector>>>();
     return {
-        activate: (component: WithWalletConnector, network: Network) => {
+        activate: (component: WithWalletConnector, network: Network, namespaceConfig: WalletConnectNamespaceConfig) => {
             const delegateConnectorPromises =
                 connectorPromises.get(component) || new Map<Network, Promise<WalletConnector>>();
             connectorPromises.set(component, delegateConnectorPromises);
-            const connectorPromise = delegateConnectorPromises.get(network) || create(component, network);
+            const connectorPromise = delegateConnectorPromises.get(network) || create(component, network, namespaceConfig);
             delegateConnectorPromises.set(network, connectorPromise);
             return connectorPromise;
         },
@@ -130,6 +130,14 @@ interface Props {
     network: Network; // reacting to change in 'componentDidUpdate'
 
     /**
+     * The namespace configuration of the connections, 
+     * i.e. which methods and events to request permission for in the wallet. 
+     * 
+     * Defaults to {@linkcode FULL_WALLET_CONNECT_NAMESPACE_CONFIG} if not set.
+     */
+    namespaceConfig?: WalletConnectNamespaceConfig;
+
+    /**
      * Function for generating the child component based on the props derived from the state of this component.
      *
      * JSX automatically supplies the nested expression as this prop field, so callers usually don't set it explicitly.
@@ -195,7 +203,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
      */
     setActiveConnectorType = (type: ConnectorType | undefined) => {
         console.debug("WithWalletConnector: calling 'setActiveConnectorType'", { type, state: this.state });
-        const { network } = this.props;
+        const { network, namespaceConfig } = this.props;
         const { activeConnectorType, activeConnector } = this.state;
         this.setState({
             activeConnectorType: type,
@@ -215,7 +223,7 @@ export class WithWalletConnector extends Component<Props, State> implements Wall
             );
         }
         if (type) {
-            type.activate(this, network)
+            type.activate(this, network, namespaceConfig)
                 .then((connector: WalletConnector) => {
                     console.log('WithWalletConnector: setting active connector', { connector });
                     // Switch the connector (type) back in case the user changed it since initiating the connection.

--- a/packages/wallet-connectors/src/WalletConnect.ts
+++ b/packages/wallet-connectors/src/WalletConnect.ts
@@ -26,7 +26,7 @@ import { WalletConnectModal, WalletConnectModalConfig } from '@walletconnect/mod
 import { MobileWallet } from '@walletconnect/modal-core';
 import SignClient from '@walletconnect/sign-client';
 import { ISignClient, ProposalTypes, SessionTypes, SignClientTypes } from '@walletconnect/types';
-import { CONCORDIUM_WALLET_CONNECT_PROJECT_ID, MAINNET, TESTNET } from '.';
+import { CONCORDIUM_WALLET_CONNECT_PROJECT_ID, MAINNET, TESTNET } from './constants';
 import {
     Network,
     Schema,
@@ -414,25 +414,36 @@ export class WalletConnectConnection implements WalletConnection {
 
     async signMessage(accountAddress: string, msg: SignableMessage) {
         switch (msg.type) {
-            case 'StringMessage': {
-                const params = { message: msg.value };
-                const signature = await this.connector.client.request({
-                    topic: this.session.topic,
-                    request: {
-                        method: 'sign_message',
-                        params,
-                    },
-                    chainId: this.chainId,
-                });
-                return signature as AccountTransactionSignature; // TODO do proper type check
-            }
+            case 'StringMessage':
+                {
+                    const params = { message: msg.value };
+                    const signature = await this.connector.client.request({
+                        topic: this.session.topic,
+                        request: {
+                            method: 'sign_message',
+                            params,
+                        },
+                        chainId: this.chainId,
+                    });
+                    return signature as AccountTransactionSignature; // TODO do proper type check
+                }
             case 'BinaryMessage':
-                throw new Error(`signing 'BinaryMessage' is not yet supported by the mobile wallets`);
+                {
+                    const params = { schema: msg.schema.value.toString('base64'), data: msg.value.toString('hex') };
+                    const signature = await this.connector.client.request({
+                        topic: this.session.topic,
+                        request: {
+                            method: 'sign_message',
+                            params,
+                        },
+                        chainId: this.chainId,
+                    });
+                    return signature as AccountTransactionSignature;
+                }
             default:
                 throw new UnreachableCaseError('message', msg);
         }
     }
-
     async requestVerifiablePresentation(
         challenge: string,
         credentialStatements: CredentialStatements

--- a/packages/wallet-connectors/src/constants.ts
+++ b/packages/wallet-connectors/src/constants.ts
@@ -1,0 +1,35 @@
+import { Network } from './WalletConnection';
+
+/**
+ * ID of the "Mobile Wallets" project in Concordium's {@link https://cloud.walletconnect.com WalletConnect Cloud} account.
+ * dApps must initialize the {@link WalletConnectConnector.create WalletConnect client} with this ID
+ * or one of a project in their own account.
+ */
+export const CONCORDIUM_WALLET_CONNECT_PROJECT_ID = '76324905a70fe5c388bab46d3e0564dc';
+
+export const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
+export const MAINNET_GENESIS_BLOCK_HASH = '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
+
+/**
+ * Standard configuration for the Testnet network.
+ */
+export const TESTNET: Network = {
+    name: 'testnet',
+    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
+    grpcOpts: {
+        baseUrl: 'https://grpc.testnet.concordium.com:20000',
+    },
+    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
+};
+
+/**
+ * Standard configuration for the Mainnet network.
+ */
+export const MAINNET: Network = {
+    name: 'mainnet',
+    genesisHash: MAINNET_GENESIS_BLOCK_HASH,
+    grpcOpts: {
+        baseUrl: 'https://grpc.mainnet.concordium.software:20000',
+    },
+    ccdScanBaseUrl: 'https://ccdscan.io',
+};

--- a/packages/wallet-connectors/src/index.ts
+++ b/packages/wallet-connectors/src/index.ts
@@ -1,39 +1,4 @@
-import { Network } from './WalletConnection';
-
+export * from './constants';
 export * from './WalletConnection';
 export * from './WalletConnect';
 export * from './BrowserWallet';
-
-/**
- * ID of the "Mobile Wallets" project in Concordium's {@link https://cloud.walletconnect.com WalletConnect Cloud} account.
- * dApps must initialize the {@link WalletConnectConnector.create WalletConnect client} with this ID
- * or one of a project in their own account.
- */
-export const CONCORDIUM_WALLET_CONNECT_PROJECT_ID = '76324905a70fe5c388bab46d3e0564dc';
-
-const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
-const MAINNET_GENESIS_BLOCK_HASH = '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
-
-/**
- * Standard configuration for the Testnet network.
- */
-export const TESTNET: Network = {
-    name: 'testnet',
-    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
-    grpcOpts: {
-        baseUrl: 'https://grpc.testnet.concordium.com:20000',
-    },
-    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
-};
-
-/**
- * Standard configuration for the Mainnet network.
- */
-export const MAINNET: Network = {
-    name: 'mainnet',
-    genesisHash: MAINNET_GENESIS_BLOCK_HASH,
-    grpcOpts: {
-        baseUrl: 'https://grpc.mainnet.concordium.software:20000',
-    },
-    ccdScanBaseUrl: 'https://ccdscan.io',
-};


### PR DESCRIPTION
## Purpose

Closes #68

## Changes

In preparation for updating the `wallet-connect-test-bench` for testing the signing of binary messages in the mobile wallets, some changes were required.

## Checklist

- [ ] Add entrypoint for binary signing in mobile wallets
- [ ] Add support to pass the `WalletConnectNamespaceConfig` instead of using the default one. This is particular useful for the `wallet-connect-test-bench` since we want to exclude `RequestVerifiablePresentation` method to be able to test legacy wallets.
- [ ] Fix circular dependency between `index` and `WalletConnect.ts` file.