### PR TITLE
react-components: Update docs on configuring connector type

### DIFF
--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -43,10 +43,13 @@ Connector types for the Browser Wallet and WalletConnect connectors are usually 
 
 ```typescript
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
-export const WALLET_CONNECT = ephemeralConnectorType(
-    WalletConnectConnector.create.bind(undefined, WALLET_CONNECT_OPTS)
+export const WALLET_CONNECT = ephemeralConnectorType((delegate, network) =>
+    WalletConnectConnector.create(walletConnectOptions, delegate, network, walletConnectNamespaceConfig)
 );
 ```
+where `walletConnectOptions` (type `SignClientTypes.Options`) is the initialization configuration for WalletConnect
+and `walletConnectNamespaceConfig` (type `WalletConnectNamespaceConfig`) is the Concordium-specific connection configuration.
+In practice, both of these values are usually constants ([`@concordium/wallet-connectors`](../wallet-connectors) includes some useful defaults for the latter).
 
 Initiate a connection by invoking `connect` on a connector.
 This is most easily done using the hooks `useConnection` and `useConnect`:

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -48,9 +48,10 @@ export const WALLET_CONNECT = ephemeralConnectorType((delegate, network) =>
 );
 ```
 
-where `walletConnectOptions` (type `SignClientTypes.Options`) is the initialization configuration for WalletConnect
-and `walletConnectNamespaceConfig` (optional, type `WalletConnectNamespaceConfig`) is the Concordium-specific connection configuration.
+where `walletConnectOptions` is the initialization configuration for WalletConnect
+and `walletConnectNamespaceConfig` is the Concordium-specific connection configuration (optional; defaults to all supported methods and events).
 In practice, both of these values are usually constants.
+See [sample configuration](../../samples/sign-message/src/config.ts) for a complete example.
 
 Initiate a connection by invoking `connect` on a connector.
 This is most easily done using the hooks `useConnection` and `useConnect`:

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -47,6 +47,7 @@ export const WALLET_CONNECT = ephemeralConnectorType((delegate, network) =>
     WalletConnectConnector.create(walletConnectOptions, delegate, network, walletConnectNamespaceConfig)
 );
 ```
+
 where `walletConnectOptions` (type `SignClientTypes.Options`) is the initialization configuration for WalletConnect
 and `walletConnectNamespaceConfig` (optional, type `WalletConnectNamespaceConfig`) is the Concordium-specific connection configuration.
 In practice, both of these values are usually constants.

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -48,8 +48,8 @@ export const WALLET_CONNECT = ephemeralConnectorType((delegate, network) =>
 );
 ```
 where `walletConnectOptions` (type `SignClientTypes.Options`) is the initialization configuration for WalletConnect
-and `walletConnectNamespaceConfig` (type `WalletConnectNamespaceConfig`) is the Concordium-specific connection configuration.
-In practice, both of these values are usually constants ([`@concordium/wallet-connectors`](../wallet-connectors) includes some useful defaults for the latter).
+and `walletConnectNamespaceConfig` (optional, type `WalletConnectNamespaceConfig`) is the Concordium-specific connection configuration.
+In practice, both of these values are usually constants.
 
 Initiate a connection by invoking `connect` on a connector.
 This is most easily done using the hooks `useConnection` and `useConnect`:


### PR DESCRIPTION
This reflects the change in #65 (3f6885acad09dce93db50667fd125026c90d879c) where the `WalletConnectNamespaceConfig` parameter was added.